### PR TITLE
Added ability to pass flags to mysqld process

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -163,6 +163,9 @@ public class DB {
         if (!config.isWindows()) {
             builder.addArgument("--socket=" + getAbsoluteSocketPath());
         }
+        for (String arg : config.getMysqldArgs()) {
+            builder.addArgument(arg);
+        }
         cleanupOnExit();
         // because cleanupOnExit() just installed our (class DB) own
         // Shutdown hook, we don't need the one from ManagedProcess:

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
@@ -19,6 +19,8 @@
  */
 package ch.vorburger.mariadb4j;
 
+import java.util.List;
+
 /**
  * Enables passing in custom options when starting up the database server
  * This is the analog to my.cnf
@@ -47,16 +49,19 @@ public interface DBConfiguration {
 	/** @return Whether running on Windows (some start-up parameters are different) */
     boolean isWindows();
 
-	
-	static class Impl implements DBConfiguration {
+    List<String> getMysqldArgs();
+
+
+    static class Impl implements DBConfiguration {
 		private final int port;
 		private final String socket;
 		private final String binariesClassPathLocation;
 		private final String baseDir;
 		private final String dataDir;
         private final boolean isWindows;
-		
-		Impl(int port, String socket, String binariesClassPathLocation, String baseDir, String dataDir, boolean isWindows) {
+        private final List<String> mysqldArgs;
+
+        Impl(int port, String socket, String binariesClassPathLocation, String baseDir, String dataDir, boolean isWindows, List<String> mysqldArgs) {
 			super();
 			this.port = port;
 			this.socket = socket;
@@ -64,7 +69,8 @@ public interface DBConfiguration {
 			this.baseDir = baseDir;
 			this.dataDir = dataDir;
 			this.isWindows = isWindows;
-		}
+            this.mysqldArgs = mysqldArgs;
+        }
 
 		@Override
 		public int getPort() {
@@ -94,6 +100,11 @@ public interface DBConfiguration {
 		@Override public boolean isWindows() {
 		    return isWindows;
 		}
-	}
+
+        @Override
+        public List<String> getMysqldArgs() {
+            return mysqldArgs;
+        }
+    }
 	
 }

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -21,6 +21,8 @@ package ch.vorburger.mariadb4j;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang3.SystemUtils;
 
@@ -45,6 +47,7 @@ public class DBConfigurationBuilder {
 	protected String socket = null; // see _getSocket()
 	protected int port = 0;
 	protected boolean isUnpackingFromClasspath = true;
+    protected List<String> mysqldArgs = new ArrayList<String>();
 	
 	private boolean frozen = false;
 	
@@ -117,10 +120,16 @@ public class DBConfigurationBuilder {
 		this.socket = socket;
 		return this;
 	}
+
+    public DBConfigurationBuilder addMysqldArg(String arg){
+        checkIfFrozen("addMysqldArg");
+        mysqldArgs.add(arg);
+        return this;
+    }
 	
 	public DBConfiguration build() {
 		frozen = true;
-        return new DBConfiguration.Impl(_getPort(), _getSocket(), _getBinariesClassPathLocation(), getBaseDir(), _getDataDir(), WIN32.equals(getOS()) );
+        return new DBConfiguration.Impl(_getPort(), _getSocket(), _getBinariesClassPathLocation(), getBaseDir(), _getDataDir(), WIN32.equals(getOS()), _getMysqldArgs());
 	}
 
     protected String _getDataDir() {
@@ -217,7 +226,10 @@ public class DBConfigurationBuilder {
     public String getURL(String databaseName) {
 		return "jdbc:mysql://localhost:" + this.getPort() + "/" + databaseName;
 	}
-	
+
+    public List<String> _getMysqldArgs(){
+        return mysqldArgs;
+    }
 	// getUID() + getPWD() ?
 	
 }


### PR DESCRIPTION
Typically one can need to pass flags when spawning a new MariaDB/Mysql process like `lower_case_table_names` for example when using mixed environments.
This is now possible by using the `addMysqldArgs`  method in the `DBConfigurationBuilder`.