### PR TITLE
Synchronize db install.

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -113,7 +113,7 @@ public class DB {
      * 
      * @throws ManagedProcessException if something fatal went wrong
      */
-    protected void install() throws ManagedProcessException {
+    synchronized protected void install() throws ManagedProcessException {
         try {
             ManagedProcess mysqlInstallProcess = installPreparation();
             mysqlInstallProcess.start();


### PR DESCRIPTION
Syncrhonize db install to try to fix some intermittent test
failures when running parallel tests in maven that depend
on MariaDB4j.