### PR TITLE
commons-collections to commons-collections4

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ MariaDB4j CONTRIBUTORS
 - Anver Sotnikov @anverus <asotnikov@tripadvisor.com>, July 2016; for http://tripadvisor.com 
 - Guillaume Hiron @ghiron; for http://www.honestica.com
 - Josef Andersson @hanklank <josef.andersson@svt.se>, July 2016; for http://www.svt.se
+- Leora Pearson @lpearson05 <Leora.Pearson@bazaarvoice.com>, Aug 2016 (http://www.bazaarvoice.com/)
 
 also see https://github.com/vorburger/MariaDB4j/graphs/contributors
 

--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -19,7 +19,7 @@
 			<!-- Just for its CircularFifoQueue... -->
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-            <version>4.1</version>
+			<version>4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -16,6 +16,12 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<!-- Just for its CircularFifoQueue... -->
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+            <version>4.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-exec</artifactId>
 			<version>1.3</version>
@@ -30,11 +36,6 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.5</version>
-		</dependency>
-		<dependency>
-			<!-- Just for its CircularFifoBuffer... -->
-			<groupId>commons-collections</groupId>
-			<artifactId>commons-collections</artifactId>
 		</dependency>
 		<dependency>
 			<!-- For ClasspathUnpacker -->

--- a/mariaDB4j-core/src/main/java/ch/vorburger/exec/RollingLogOutputStream.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/exec/RollingLogOutputStream.java
@@ -21,7 +21,7 @@ package ch.vorburger.exec;
 
 import java.util.Collection;
 
-import org.apache.commons.collections.buffer.CircularFifoBuffer;
+import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.apache.commons.exec.LogOutputStream;
 
 /**
@@ -36,7 +36,7 @@ class RollingLogOutputStream extends LogOutputStream {
 
     @SuppressWarnings("unchecked")
     RollingLogOutputStream(int maxLines) {
-        ringBuffer = new CircularFifoBuffer(maxLines);
+        ringBuffer = new CircularFifoQueue(maxLines);
     }
 
     @Override


### PR DESCRIPTION
motivation:
* dependencies consolidation
* current dependenies
* CVE-2011-2092 vulnerable code was completely removed
  from 4.1, whereas in 3.2.2 it was merely disabled
  (and can be re-enabled)
   * http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-2092
   * https://issues.apache.org/jira/browse/COLLECTIONS-580
   * https://commons.apache.org/proper/commons-collections/release_3_2_2.html
   * https://commons.apache.org/proper/commons-collections/release_4_1.html