### PR TITLE
Changed so that empty password string is treated the same as null

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -254,11 +254,11 @@ public class DB {
             ManagedProcessBuilder builder = new ManagedProcessBuilder(newExecutableFile("bin", "mysql"));
             builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mysql"));
             builder.setWorkingDirectory(baseDir);
-            if (username != null)
+            if (username != null && !username.isEmpty())
                 builder.addArgument("-u", username);
-            if (password != null)
+            if (password != null && !password.isEmpty())
                 builder.addArgument("-p", password);
-            if (dbName != null)
+            if (dbName != null && !dbName.isEmpty())
                 builder.addArgument("-D", dbName);
             addSocketOrPortArgument(builder);
             if (fromIS != null)

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleTutorialTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleTutorialTest.java
@@ -73,8 +73,9 @@ public class MariaDB4jSampleTutorialTest {
 
             // Should be able to source a SQL file
             db.source("ch/vorburger/mariadb4j/testSourceFile.sql", "root", null, dbName);
+            db.source("ch/vorburger/mariadb4j/testSourceFile.sql", "root", "", dbName);
             results = qr.query(conn, "SELECT * FROM hello", new ColumnListHandler<String>());
-            Assert.assertEquals(3, results.size());
+            Assert.assertEquals(5, results.size());
             Assert.assertEquals("Hello, world", results.get(0));
             Assert.assertEquals("Bonjour, monde", results.get(1));
             Assert.assertEquals("Hola, mundo", results.get(2));


### PR DESCRIPTION
Previously the empty password string was passed on to the mysql
command line tool resulting in mysql asking for a password and
stalling the test run.

Solves issue #66