### PR TITLE
MariaDB4jSampleDumpTest should waitForExit() ManagedProcess

### DIFF
--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleDumpTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleDumpTest.java
@@ -19,10 +19,20 @@
  */
 package ch.vorburger.mariadb4j.tests;
 
-import ch.vorburger.exec.ManagedProcess;
-import ch.vorburger.exec.ManagedProcessException;
-import ch.vorburger.mariadb4j.DB;
-import ch.vorburger.mariadb4j.DBConfigurationBuilder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.handlers.ColumnListHandler;
 import org.apache.commons.io.FileUtils;
@@ -32,19 +42,10 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import ch.vorburger.exec.ManagedProcess;
+import ch.vorburger.exec.ManagedProcessException;
+import ch.vorburger.mariadb4j.DB;
+import ch.vorburger.mariadb4j.DBConfigurationBuilder;
 
 /**
  * Tests the functioning of MariaDB4j Dump/Restore illustrating how to use MariaDB4j.
@@ -53,12 +54,11 @@ import static org.junit.Assert.fail;
  */
 public class MariaDB4jSampleDumpTest {
 
-    private  DB db;
-    private  DBConfigurationBuilder config;
-    private static final String DBNAME="planetexpress";
+    private DB db;
+    private DBConfigurationBuilder config;
+    private static final String DBNAME = "planetexpress";
 
-    @Before
-    public void beforeTest() throws ManagedProcessException, SQLException {
+    @Before public void beforeTest() throws ManagedProcessException, SQLException {
         config = DBConfigurationBuilder.newBuilder();
         config.setPort(0);
         db = DB.newEmbeddedDB(// 0 => autom. detect free port
@@ -72,29 +72,28 @@ public class MariaDB4jSampleDumpTest {
         conn = DriverManager.getConnection(config.getURL(DBNAME), "root", "");
         QueryRunner qr = new QueryRunner();
         // Should be able to create a new table
-        List<String> results=qr.query(conn, "SELECT * FROM crew;",new ColumnListHandler<String>());
+        List<String> results = qr.query(conn, "SELECT * FROM crew;", new ColumnListHandler<String>());
         assertEquals(4, results.size());
-        assertEquals("John A Zoidberg",results.get(2));
+        assertEquals("John A Zoidberg", results.get(2));
     }
 
-    @Test
-    public void simpleDump() throws IOException, ManagedProcessException, SQLException {
-        File outputDumpFile = File.createTempFile("sqlDump ",".sql");
-        ManagedProcess dumpProcess = db.dumpSQL(outputDumpFile, DBNAME,"root","");
+    @Test public void sqlDump() throws IOException, ManagedProcessException, SQLException {
+        File outputDumpFile = File.createTempFile("sqlDump ", ".sql");
+        ManagedProcess dumpProcess = db.dumpSQL(outputDumpFile, DBNAME, "root", "");
         dumpProcess.start();
+        assertEquals(0, dumpProcess.waitForExit());
         assertTrue(outputDumpFile.exists() || outputDumpFile.isDirectory());
-        assertTrue(FileUtils.sizeOf(outputDumpFile)>0);
+        assertTrue(FileUtils.sizeOf(outputDumpFile) > 0);
         FileUtils.forceDeleteOnExit(outputDumpFile);
     }
 
-
-    @Test
-    public void xmlDump() throws IOException, SAXException, ManagedProcessException, ParserConfigurationException, SQLException {
-        File outputDumpFile = File.createTempFile("xmlsqlDump",".xml");
-        ManagedProcess dumpProcess = db.dumpXML(outputDumpFile,DBNAME,"root","");
+    @Test public void xmlDump() throws IOException, SAXException, ManagedProcessException, ParserConfigurationException, SQLException {
+        File outputDumpFile = File.createTempFile("xmlsqlDump", ".xml");
+        ManagedProcess dumpProcess = db.dumpXML(outputDumpFile, DBNAME, "root", "");
         dumpProcess.start();
+        assertEquals(0, dumpProcess.waitForExit());
         assertTrue(outputDumpFile.exists() || outputDumpFile.isDirectory());
-        assertTrue(FileUtils.sizeOf(outputDumpFile)>0);
+        assertTrue(FileUtils.sizeOf(outputDumpFile) > 0);
         // We just want to check that the file is a valid XML, output of it is mysqldump's responsability
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
@@ -102,8 +101,7 @@ public class MariaDB4jSampleDumpTest {
         FileUtils.forceDeleteOnExit(outputDumpFile);
     }
 
-    @After
-    public  void afterTest() throws ManagedProcessException {
+    @After public void afterTest() throws ManagedProcessException {
         db.stop();
     }
 }


### PR DESCRIPTION
@cortiz FYI, I think in the new MariaDB4jSampleDumpTest we have to waitForExit() for this test to be reliable - it currently probably just "happens" to work because it typically runs slow enough, but it's not truly concurrency safe as is. Adding the waitForExit() should do the trick though.