### PR TITLE
 Switch .travis.yml from oraclejdk7 to openjdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: java
-# We need Java 7, even though the source code is still Java 6, because Checkstyle during build is Java 7+ only
+
+# We need Java 7, even though the source code is still Java 6, 
+# because Checkstyle during build is Java 7+ only; and we use
+# OpenJDK instead of Oracle JDK because ya all should only
+# ever use OpenJDK!  (And get Red Hat's support for it, if
+# you use it professionally.)
 jdk: 
-  - oraclejdk7
+  - openjdk7
 
 before_install:
   - mvn -f DBs/pom.xml clean install


### PR DESCRIPTION
As mvn fails on https://travis-ci.org/vorburger/MariaDB4j/builds/256517304 :

$ javac -J-Xmx32m -version

javac 1.8.0_131

$ mvn -f DBs/pom.xml clean install

Error: JAVA_HOME is not defined correctly.

  We cannot execute /usr/lib/jvm/java-7-oracle/bin/java

The command "mvn -f DBs/pom.xml clean install" failed and exited with 1 during .