### PR TITLE
make MariaDB4jService throws ManagedProcessRuntimeException (fixes #88)

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/ManagedProcessRuntimeException.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/ManagedProcessRuntimeException.java
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * MariaDB4j
+ * %%
+ * Copyright (C) 2012 - 2018 Michael Vorburger
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ch.vorburger.mariadb4j;
+
+import ch.vorburger.exec.ManagedProcess;
+import ch.vorburger.exec.ManagedProcessException;
+
+/**
+ * Exception thrown when unexpected thing happen in {@link ManagedProcess} and
+ * <a href="https://github.com/vorburger/MariaDB4j/issues/88">caller needs an unchecked instead of a checked exception</a>.
+ * 
+ * @author Michael Vorburger.ch
+ */
+public class ManagedProcessRuntimeException extends RuntimeException {
+
+    private static final long serialVersionUID = -415492090964791430L;
+
+    public ManagedProcessRuntimeException(ManagedProcessException original) {
+        super(original.getMessage(), original.getCause());
+    }
+
+}

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/MariaDB4jService.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/MariaDB4jService.java
@@ -60,15 +60,29 @@ public class MariaDB4jService {
         return configBuilder;
     }
 
-    @PostConstruct
-    // note this is from javax.annotation, not a Spring Framework dependency
+    @PostConstruct // note this is from javax.annotation, not a Spring Framework dependency
+    public void postConstruct() throws ManagedProcessRuntimeException {
+        try {
+            start();
+        } catch (ManagedProcessException e) {
+            throw new ManagedProcessRuntimeException(e);
+        }
+    }
+
     public void start() throws ManagedProcessException {
         db = DB.newEmbeddedDB(getConfiguration().build());
         db.start();
     }
 
-    @PreDestroy
-    // note this is from javax.annotation, not a Spring Framework dependency
+    @PreDestroy // note this is from javax.annotation, not a Spring Framework dependency
+    public void preDestroy() throws ManagedProcessRuntimeException {
+        try {
+            stop();
+        } catch (ManagedProcessException e) {
+            throw new ManagedProcessRuntimeException(e);
+        }
+    }
+
     public void stop() throws ManagedProcessException {
         if (!isRunning())
             return;


### PR DESCRIPTION
from its @PostConstruct and @PreDestroy annotated methods

because of https://github.com/vorburger/MariaDB4j/issues/88