### PR TITLE
remove <version>1.5.5 from mariadb-java-client which bumps it to 2.2.3

### DIFF
--- a/mariaDB4j/pom.xml
+++ b/mariaDB4j/pom.xml
@@ -59,7 +59,6 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>1.5.5</version>
             <scope>test</scope>
         </dependency>
 <!--   <dependency>


### PR DESCRIPTION
The artifact is managed in
org.springframework.boot:spring-boot-dependencies:2.0.2.RELEASE