### PR TITLE
Only set --max_allowed_packet if it is not in the configured arguments

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@ MariaDB4j CONTRIBUTORS
 .com/)
 - Jai Deep Mulchandani [@jai-deep](https://github.com/jai-deep) <Jaideep.Mulchandani@walmart.com> Jan 2018; for http://walmartlabs.com 
 - Lukasz Degus [@lde-avaleo] <lde@avaleo.net>, Jan 2018
+- Andrew Groot [@thesquaregroot](https://github.com/thesquaregroot) <groot@softwareverde.com>, June 2018; for https://softwareverde.com
 
 also see https://github.com/vorburger/MariaDB4j/graphs/contributors
 

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -177,7 +177,9 @@ public class DB {
         if(this.configuration.isSecurityDisabled()) {
             builder.addArgument("--skip-grant-tables");
         }
-        builder.addArgument("--max_allowed_packet=64M");
+        if (! hasArgument("--max_allowed_packet")) {
+            builder.addArgument("--max_allowed_packet=64M");
+        }
         builder.addFileArgument("--basedir", baseDir).setWorkingDirectory(baseDir);
         builder.addFileArgument("--datadir", dataDir);
         addPortAndMaybeSocketArguments(builder);
@@ -190,6 +192,15 @@ public class DB {
         builder.setDestroyOnShutdown(false);
         logger.info("mysqld executable: " + builder.getExecutable());
         return builder.build();
+    }
+
+    protected boolean hasArgument(final String argumentName) {
+        for (String argument : this.configuration.getArgs()) {
+            if (argument.startsWith(argumentName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     protected File newExecutableFile(String dir, String exec) {


### PR DESCRIPTION
In one of our projects, we were planning to change the max_allowed_packet parameter but since this was automatically being set we wanted to confirm that our value would override the 64M value set automatically by MariaDB4j.

I had difficulty finding documentation confirming that the expected behavior of repeated command-line arguments is that the last value will be used.  In addition, having this set multiple times to different values could generally cause confusion.

This change simply checks the arguments that have been configured to see if it has already been set and only adds the parameter if it will not appear later.