### PR TITLE
Add mariaDB4j-springboot module for auto-configuration with spring boot

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@ MariaDB4j CONTRIBUTORS
 - Andrew Groot [@thesquaregroot](https://github.com/thesquaregroot) <groot@softwareverde.com>, June 2018; for https://softwareverde.com
 - Yftach Zur [@yiftizur](https://github.com/yiftizur), June 2018; for MariaDB4jRule for easy integration with JUnit
 - William Dutton [@duttonw](https://github.com/duttonw)<will.dutt@gmail.com>, June 2018; for mariaDB4j-maven-plugin integration testing of micro services under services.qld.gov.au
+- Yuexiang Gao [@kbyyd24](https://github.com/kbyyd24) <melo@gaoyuexiang.cn> (http://blog.gaoyuexiang.cn), August 2018; for mariaDB4j-springboot auto-configure with spring boot 
 - also see https://github.com/vorburger/MariaDB4j/graphs/contributors
 
 Contributions, patches, forks more than welcome - hack it, and add your name here! ;-)

--- a/mariaDB4j-springboot/pom.xml
+++ b/mariaDB4j-springboot/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ch.vorburger.mariaDB4j</groupId>
+        <artifactId>mariaDB4j-pom</artifactId>
+        <version>2.3.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mariaDB4j-springboot</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mariaDB4j</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/mariaDB4j-springboot/src/main/java/ch/vorburger/mariadb4j/springboot/autoconfigure/DataSourceAutoConfiguration.java
+++ b/mariaDB4j-springboot/src/main/java/ch/vorburger/mariadb4j/springboot/autoconfigure/DataSourceAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * MariaDB4j
+ * %%
+ * Copyright (C) 2012 - 2014 Michael Vorburger
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ch.vorburger.mariadb4j.springboot.autoconfigure;
+
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+
+import javax.sql.DataSource;
+
+//separate with MariaDB4jSpringConfiguration for test of it
+@Configuration
+@ConfigurationProperties("spring.datasource")
+public class DataSourceAutoConfiguration {
+
+    @Bean
+    @DependsOn("mariaDB4j")
+    public DataSource dataSource(DataSourceProperties dataSourceProperties) {
+        return DataSourceBuilder.create()
+                .driverClassName(dataSourceProperties.getDriverClassName())
+                .url(dataSourceProperties.getUrl())
+                .username(dataSourceProperties.getUsername())
+                .password(dataSourceProperties.getPassword())
+                .build();
+    }
+}

--- a/mariaDB4j-springboot/src/main/java/ch/vorburger/mariadb4j/springboot/autoconfigure/MariaDB4jSpringConfiguration.java
+++ b/mariaDB4j-springboot/src/main/java/ch/vorburger/mariadb4j/springboot/autoconfigure/MariaDB4jSpringConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * MariaDB4j
+ * %%
+ * Copyright (C) 2012 - 2014 Michael Vorburger
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ch.vorburger.mariadb4j.springboot.autoconfigure;
+
+import ch.vorburger.mariadb4j.springframework.MariaDB4jSpringService;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties
+public class MariaDB4jSpringConfiguration {
+
+    @Bean
+    public MariaDB4jSpringService mariaDB4j() {
+        return new MariaDB4jSpringService();
+    }
+
+}

--- a/mariaDB4j-springboot/src/main/resources/META-INF/spring.factories
+++ b/mariaDB4j-springboot/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  ch.vorburger.mariadb4j.springboot.autoconfigure.MariaDB4jSpringConfiguration,\
+  ch.vorburger.mariadb4j.springboot.autoconfigure.DataSourceAutoConfiguration

--- a/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/springboot/autoconfigure/MariaDB4JSpringConfigurationTest.java
+++ b/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/springboot/autoconfigure/MariaDB4JSpringConfigurationTest.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * MariaDB4j
+ * %%
+ * Copyright (C) 2012 - 2014 Michael Vorburger
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ch.vorburger.mariadb4j.springboot.autoconfigure;
+
+import ch.vorburger.mariadb4j.springframework.MariaDB4jSpringService;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MariaDB4JSpringConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(MariaDB4jSpringConfiguration.class));
+
+    @Test
+    public void shouldAutoConfigureEmbeddedMariaDB() {
+        this.contextRunner.withUserConfiguration(MariaDB4jSpringConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(MariaDB4jSpringService.class);
+                    assertThat(context.getBean(MariaDB4jSpringService.class))
+                            .isSameAs(context.getBean(MariaDB4jSpringConfiguration.class).mariaDB4j());
+                });
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<module>mariaDB4j-core</module>
 		<module>mariaDB4j</module>
 		<module>mariaDB4j-app</module>
+		<module>mariaDB4j-springboot</module>
 		<module>mariaDB4j-maven-plugin</module>
 	</modules>
 


### PR DESCRIPTION
Add a module named mariaDB4j-springboot, it will auto-configure `MariaDBSpringService` as a bean named `mariaDB4j`, and initialize bean `dataSource` after `mariaDB4j` initialized by annotation `@DependsOn`.
So now, we can use mariaDB4j with spring boot with dependency of mariaDB4j-springboot. For example, we can configure gradle like this:

```gradle
dependencies {
    compile 'org.springframework.boot:spring-boot-starter'
    testCompile 'ch.vorburger.mariaDB4j:mariaDB4j-springboot:2.3.1-SNAPSHOT'
}
```