### PR TITLE
use fixed versions of maven-jar-plugin and maven-invoker-plugin

### DIFF
--- a/mariaDB4j-maven-plugin/pom.xml
+++ b/mariaDB4j-maven-plugin/pom.xml
@@ -28,7 +28,7 @@
             <artifactId>mariaDB4j</artifactId>
             <version>${project.version}</version>
         </dependency>
-       <dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -181,6 +181,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -259,6 +260,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
+                        <version>3.1.0</version>
                         <configuration>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
                         </configuration>


### PR DESCRIPTION
This fixes the Maven warnings which appear on the build:

```
[WARNING] Some problems were encountered while building the effective model for ch.vorburger.mariaDB4j:mariaDB4j-maven-plugin:maven-plugin:2.3.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ ch.vorburger.mariaDB4j:mariaDB4j-maven-plugin:[unknown-version], /home/vorburger/dev/MariaDB4j/git/MariaDB4j/mariaDB4j-maven-plugin/pom.xml, line 181, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-invoker-plugin is missing. @ ch.vorburger.mariaDB4j:mariaDB4j-maven-plugin:[unknown-version], /home/vorburger/dev/MariaDB4j/git/MariaDB4j/mariaDB4j-maven-plugin/pom.xml, line 259, column 29
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```