### PR TITLE
Fixes #265

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -282,10 +282,13 @@ public class DB {
      * @throws ManagedProcessException if something fatal went wrong
      */
     public void source(String resource, String username, String password, String dbName, boolean force) throws ManagedProcessException {
-        InputStream from = getClass().getClassLoader().getResourceAsStream(resource);
-        if (from == null)
-            throw new IllegalArgumentException("Could not find script file on the classpath at: " + resource);
-        run("script file sourced from the classpath at: " + resource, from, username, password, dbName, force);
+        try (InputStream from = getClass().getClassLoader().getResourceAsStream(resource)) {
+            if (from == null)
+                throw new IllegalArgumentException("Could not find script file on the classpath at: " + resource);
+            run("script file sourced from the classpath at: " + resource, from, username, password, dbName, force);
+        } catch (IOException ioe) {
+            logger.warn("Issue trying to close source InputStream. Raise warning and continue.", ioe);
+        }
     }
 
     public void run(String command, String username, String password, String dbName) throws ManagedProcessException {
@@ -301,8 +304,13 @@ public class DB {
     }
 
     public void run(String command, String username, String password, String dbName, boolean force) throws ManagedProcessException {
-        InputStream from = IOUtils.toInputStream(command, Charset.defaultCharset());
-        run("command: " + command, from, username, password, dbName, force);
+        // If resource is created here, it should probably be released here also (as opposed to in protected run method)
+        // Also move to try-with-resource syntax to remove closeQuietly deprecation errors.
+        try (InputStream from = IOUtils.toInputStream(command, Charset.defaultCharset())) {
+            run("command: " + command, from, username, password, dbName, force);
+        } catch (IOException ioe) {
+            logger.warn("Issue trying to close source InputStream. Raise warning and continue.", ioe);
+        }
     }
 
     protected void run(String logInfoText, InputStream fromIS, String username, String password, String dbName, boolean force)
@@ -332,8 +340,6 @@ public class DB {
             process.waitForExit();
         } catch (Exception e) {
             throw new ManagedProcessException("An error occurred while running a " + logInfoText, e);
-        } finally {
-            IOUtils.closeQuietly(fromIS);
         }
         logger.info("Successfully ran the " + logInfoText);
     }

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -20,6 +20,8 @@
 package ch.vorburger.mariadb4j;
 
 import ch.vorburger.exec.ManagedProcessListener;
+
+import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
@@ -197,7 +199,7 @@ public class DBConfigurationBuilder {
 
     protected String _getDataDir() {
         if (isNull(getDataDir()) || getDataDir().equals(DEFAULT_DATA_DIR))
-            return DEFAULT_DATA_DIR + SystemUtils.FILE_SEPARATOR + getPort();
+            return DEFAULT_DATA_DIR + File.separator + getPort();
         else
             return getDataDir();
     }

--- a/mariaDB4j-maven-plugin/src/main/java/ch/vorburger/mariadb4j/AbstractRunMojo.java
+++ b/mariaDB4j-maven-plugin/src/main/java/ch/vorburger/mariadb4j/AbstractRunMojo.java
@@ -34,7 +34,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 /**

--- a/mariaDB4j-maven-plugin/src/main/java/ch/vorburger/mariadb4j/StartMojo.java
+++ b/mariaDB4j-maven-plugin/src/main/java/ch/vorburger/mariadb4j/StartMojo.java
@@ -54,7 +54,7 @@ public class StartMojo extends AbstractRunMojo {
             if (!databaseName.equals("test")) {
                 // mysqld out-of-the-box already has a DB named "test"
                 // in case we need another DB, here's how to create it first
-               db.createDB(databaseName);
+                db.createDB(databaseName);
             }
             this.runScripts(db, databaseName);
 

--- a/mariaDB4j-maven-plugin/src/test/java/ch/vorburger/mariaDB4j/DbUtils.java
+++ b/mariaDB4j-maven-plugin/src/test/java/ch/vorburger/mariaDB4j/DbUtils.java
@@ -37,7 +37,6 @@ import static com.google.common.base.Preconditions.checkArgument;
  * @author mike10004
  * @author William Dutton
  */
-@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
 class DbUtils {
     private DbUtils() {}
 

--- a/mariaDB4j-maven-plugin/src/test/java/ch/vorburger/mariaDB4j/Mariadb4jStartMojoTest.java
+++ b/mariaDB4j-maven-plugin/src/test/java/ch/vorburger/mariaDB4j/Mariadb4jStartMojoTest.java
@@ -54,6 +54,7 @@ import static org.junit.Assert.*;
 
 public class Mariadb4jStartMojoTest {
 
+    @SuppressWarnings("rawtypes")
     private Map pluginContext;
 
     @Rule
@@ -74,7 +75,6 @@ public class Mariadb4jStartMojoTest {
 
     private static final String BASIC_TABLE_NAME = "bar";
     private static final String BASIC_DB_NAME = "foo";
-    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
     private static final String BASIC_TABLE_INSERT_STMT = "INSERT INTO bar (baz) VALUES (?)";
     private static final String BASIC_TABLE_VALUE_COLUMN = "baz";
 

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleDumpTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleDumpTest.java
@@ -39,7 +39,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import ch.vorburger.exec.ManagedProcess;
@@ -97,7 +96,7 @@ public class MariaDB4jSampleDumpTest {
         // We just want to check that the file is a valid XML, output of it is mysqldump's responsability
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-        Document doc = dBuilder.parse(outputDumpFile);
+        dBuilder.parse(outputDumpFile);
         FileUtils.forceDeleteOnExit(outputDumpFile);
     }
 


### PR DESCRIPTION
Amongst others. Attempt to remove annoying warnings in build including:
1. deprecated closeQuielty methods. Replaced with try-with clauses which auto-close the resource. Moved allocation and close of resources to same methods so logic is clearer.
2. Removed Intellij IDEA specific SuppressWarnings. These caused subsequent warnings in Eclipse, VSCode and Intellij IDEA Communtity Edition without specific SQL plugins beng available.
3. Some checkstyle spacing warnings.
4. Added a SuppressWarnings("rawtype") for an unparameterised Map. Belive this warning is common to Eclipse, VSCode...
5. Removed deprecated SystemUtils.FILE_SEPARATOR
6. Removed some unused imports