### PR TITLE
Fixes #257 - maven-checkstyle-plugin:3.1.0

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -38,9 +38,7 @@ http://www.vorburger.ch
     <module name="NeedBraces">
       <property name="tokens" value="LITERAL_DO,LITERAL_FOR,LITERAL_WHILE"/>
     </module>
-    <module name="LeftCurly">
-      <property name="maxLineLength" value="100"/>
-    </module>
+    <module name="LeftCurly"/>
     <module name="RightCurly"/>
     <module name="RightCurly">
       <property name="option" value="alone"/>


### PR DESCRIPTION
The LeftCurlyCheck maxLineLength property was removed from Checkstyle as it was a kludge for lines that were probably too long anyway.
I have simply removed the property from MariaDB4j, but left the LeftCurlyCheck active. There are no checkstyle errors following its removal.

I have only commited the required checkstyle.xml change. I am assuming dependabot will make the necessary pom.xml changes when #257 is rebased?