### PR TITLE
Bug fix: dataDir is checked and not the baseDir

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -440,7 +440,7 @@ public class DB {
                     FileUtils.deleteQuietly(dataDir);
                 }
                 if (baseDir.exists() && (configuration.isDeletingTemporaryBaseAndDataDirsOnShutdown() 
-                                    && Util.isTemporaryDirectory(dataDir.getAbsolutePath()))) {
+                                    && Util.isTemporaryDirectory(baseDir.getAbsolutePath()))) {
                     logger.info("cleanupOnExit() ShutdownHook quietly deleting temporary DB base directory: " + baseDir);
                     FileUtils.deleteQuietly(baseDir);
                 }


### PR DESCRIPTION
The cleanup on exit feature checks if the `dataDir` folder is temporary and not the `baseDir` as intended.