### PR TITLE
Reduce file copying during classpath unpacking.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@ MariaDB4j CONTRIBUTORS
 - Yuexiang Gao [@kbyyd24](https://github.com/kbyyd24) <melo@gaoyuexiang.cn> (http://blog.gaoyuexiang.cn), August 2018; for mariaDB4j-springboot auto-configure with spring boot
 - Neelesh Shastry [@neeleshs](https://github.com/neeleshs), Dec 2017 Provide a callback if the DB process crashes
 - Gordon Little [@glittle1972](https://github.com/glittle1972), Jun 2019 Add option to force continue-on-error for sourcing SQL scripts
+- Theodore Ni [@tjni](https://github.com/tjni), Aug 2019 Reduce file copying during classpath unpacking
 - also see https://github.com/vorburger/MariaDB4j/graphs/contributors
 
 Contributions, patches, forks more than welcome - hack it, and add your name here! ;-)

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/Util.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/Util.java
@@ -153,12 +153,14 @@ public class Util {
     @SuppressWarnings("null")
     private static void tryN(int n, long msToWait, Procedure<IOException> procedure) throws IOException {
         IOException lastIOException = null;
-        int attemps = 0;
-        while (attemps++ < n) {
+        int numAttempts = 0;
+        while (numAttempts++ < n) {
             try {
                 procedure.apply();
+                return;
             } catch (IOException e) {
-                logger.warn("Failure " + attemps + " of " + n + ", retrying again in " + msToWait + "ms", e);
+                lastIOException = e;
+                logger.warn("Failure {} of {}, retrying again in {}ms", numAttempts, n, msToWait, e);
                 try {
                     Thread.sleep(msToWait);
                 } catch (InterruptedException interruptedException) {
@@ -166,9 +168,7 @@ public class Util {
                 }
             }
         }
-        if (attemps == 3) {
-            throw lastIOException;
-        }
+        throw lastIOException;
     }
 
     private static interface Procedure<E extends Throwable> {


### PR DESCRIPTION
The tryN method can return early when the procedure it runs is successful.

We are noticing that file copying is surprisingly slow on our RHEL CI hosts (some files taking a whole second to copy, repeated 5 times since tryN is called with n = 5). It's not clear why this is slow for us, but this will reduce the time needed by a factor of 5 (i.e. 2 minutes to 24 seconds).

The existing tests in ClasspathUnpackerTest look like suitable coverage and continue to pass.