### PR TITLE
Bump MariaDB from 10.3.13 to 10.3.16

### DIFF
--- a/DBs/mariaDB4j-db-10.3/mariaDB4j-db-linux64-10.3/pom.xml
+++ b/DBs/mariaDB4j-db-10.3/mariaDB4j-db-linux64-10.3/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
 	<artifactId>mariaDB4j-db-linux64</artifactId>
-	<version>10.3.13</version>
+	<version>10.3.16</version>
 
     <properties>
         <mariaDB.version>${project.version}</mariaDB.version>

--- a/DBs/mariaDB4j-db-10.3/mariaDB4j-db-mac64-10.3/pom.xml
+++ b/DBs/mariaDB4j-db-10.3/mariaDB4j-db-mac64-10.3/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
 	<artifactId>mariaDB4j-db-mac64</artifactId>
-	<version>10.3.13</version>
+	<version>10.3.16</version>
 
     <properties>
         <mariaDB.version>${project.version}</mariaDB.version>

--- a/DBs/mariaDB4j-db-10.3/mariaDB4j-db-win32-10.3/pom.xml
+++ b/DBs/mariaDB4j-db-10.3/mariaDB4j-db-win32-10.3/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
 	<artifactId>mariaDB4j-db-win32</artifactId>
-	<version>10.3.13</version>
+	<version>10.3.16</version>
 
     <properties>
         <mariaDB.version>${project.version}</mariaDB.version>

--- a/DBs/mariaDB4j-db-10.3/mariaDB4j-db-winx64-10.3/pom.xml
+++ b/DBs/mariaDB4j-db-10.3/mariaDB4j-db-winx64-10.3/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
 	<artifactId>mariaDB4j-db-winx64</artifactId>
-	<version>10.3.13</version>
+	<version>10.3.16</version>
 
     <properties>
         <mariaDB.version>${project.version}</mariaDB.version>

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -250,11 +250,11 @@ public class DBConfigurationBuilder {
         String databaseVersion = getDatabaseVersion();
         if (databaseVersion == null) {
             if (OSX.equals(getOS()))
-                databaseVersion = "mariadb-10.3.13";
+                databaseVersion = "mariadb-10.3.16";
             else if (LINUX.equals(getOS()))
-                databaseVersion = "mariadb-10.3.13";
+                databaseVersion = "mariadb-10.3.16";
             else if (WIN32.equals(getOS()))
-                databaseVersion = "mariadb-10.3.13";
+                databaseVersion = "mariadb-10.3.16";
             else
                 throw new IllegalStateException(
                         "OS not directly supported, please use setDatabaseVersion() to set the name "

--- a/mariaDB4j/pom.xml
+++ b/mariaDB4j/pom.xml
@@ -21,17 +21,17 @@
 		<dependency>
 			<groupId>ch.vorburger.mariaDB4j</groupId>
 			<artifactId>mariaDB4j-db-linux64</artifactId>
-			<version>10.3.13</version>
+			<version>10.3.16</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.vorburger.mariaDB4j</groupId>
 			<artifactId>mariaDB4j-db-win32</artifactId>
-			<version>10.3.13</version>
+			<version>10.3.16</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.vorburger.mariaDB4j</groupId>
 			<artifactId>mariaDB4j-db-mac64</artifactId>
-			<version>10.3.13</version>
+			<version>10.3.16</version>
 		</dependency>
 		<dependency>
 			<!-- For MariaDB4jSpringService, only. This has to be repeated from mariaDB4j-core here due to the optional true below -->


### PR DESCRIPTION
NB that while there's already a 10.3.17 for Linux and Windows on https://downloads.mariadb.org, the latest Homebrew for Mac on Bintray is only 10.3.6 at https://bintray.com/homebrew/bottles/mariadb; see #292.