### PR TITLE
Attempt to install mysql N times, if not able to complete within a configurable timeout

### DIFF
--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>ch.vorburger.exec</groupId>
             <artifactId>exec</artifactId>
-            <version>3.1.1</version>
+            <version>3.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -45,6 +45,10 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,14 +30,14 @@ import java.util.function.Function;
  */
 public interface DBConfiguration {
 
-    /** 
-     * TCP Port to start DB server on. 
+    /**
+     * TCP Port to start DB server on.
      * @return returns port value
      **/
     int getPort();
 
-    /** 
-     * UNIX Socket to start DB server on (ignored on Windows). 
+    /**
+     * UNIX Socket to start DB server on (ignored on Windows).
      * @return returns socket value
      **/
     String getSocket();
@@ -48,16 +48,16 @@ public interface DBConfiguration {
      */
     String getBinariesClassPathLocation();
 
-    /** 
-     * Base directory where DB binaries are expected to be found. 
+    /**
+     * Base directory where DB binaries are expected to be found.
      * @return returns base directory value
      **/
     String getBaseDir();
 
     String getLibDir();
 
-    /** 
-     * Base directory for DB's actual data files. 
+    /**
+     * Base directory for DB's actual data files.
      * @return returns data directory value
      **/
     String getDataDir();
@@ -71,8 +71,8 @@ public interface DBConfiguration {
      */
     boolean isDeletingTemporaryBaseAndDataDirsOnShutdown();
 
-    /** 
-     * Whether running on Windows (some start-up parameters are different). 
+    /**
+     * Whether running on Windows (some start-up parameters are different).
      * @return returns boolean isWindows
      **/
     boolean isWindows();
@@ -87,11 +87,15 @@ public interface DBConfiguration {
      */
     ManagedProcessListener getProcessListener();
 
-    /** 
-     * Whether to to "--skip-grant-tables". 
+    /**
+     * Whether to to "--skip-grant-tables".
      * @return returns boolean isSecurityDisabled value
      **/
     boolean isSecurityDisabled();
+
+    int getInstallationTimeoutInMs();
+
+    int getTimesToAttemptInstall();
 
     String getURL(String dbName);
 
@@ -108,12 +112,15 @@ public interface DBConfiguration {
         private final List<String> args;
         private final String osLibraryEnvironmentVarName;
         private final ManagedProcessListener listener;
+        private int installationTimeoutInMs;
+        private int timesToAttemptInstall;
         private final boolean isSecurityDisabled;
         private final Function<String, String> getURL;
 
         Impl(int port, String socket, String binariesClassPathLocation, String baseDir, String libDir, String dataDir,
-             boolean isWindows, List<String> args, String osLibraryEnvironmentVarName, boolean isSecurityDisabled,
-             boolean isDeletingTemporaryBaseAndDataDirsOnShutdown, Function<String, String> getURL, ManagedProcessListener listener) {
+            boolean isWindows, List<String> args, String osLibraryEnvironmentVarName, boolean isSecurityDisabled,
+            boolean isDeletingTemporaryBaseAndDataDirsOnShutdown, Function<String, String> getURL,
+            ManagedProcessListener listener, int installationTimeoutInMs, int timesToAttemptInstall) {
             super();
             this.port = port;
             this.socket = socket;
@@ -128,6 +135,8 @@ public interface DBConfiguration {
             this.isSecurityDisabled = isSecurityDisabled;
             this.getURL = getURL;
             this.listener = listener;
+            this.installationTimeoutInMs = installationTimeoutInMs;
+            this.timesToAttemptInstall = timesToAttemptInstall;
         }
 
         @Override
@@ -186,6 +195,11 @@ public interface DBConfiguration {
         }
 
         @Override
+        public int getInstallationTimeoutInMs() {
+            return installationTimeoutInMs;
+        }
+
+        @Override
         public String getURL(String dbName) {
             return getURL.apply(dbName);
         }
@@ -193,6 +207,10 @@ public interface DBConfiguration {
         @Override
         public ManagedProcessListener getProcessListener() {
             return listener;
+        }
+
+        public int getTimesToAttemptInstall() {
+            return timesToAttemptInstall;
         }
     }
 

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -54,6 +54,9 @@ public class DBConfigurationBuilder {
     private boolean isSecurityDisabled = true;
 
     private boolean frozen = false;
+    private int installationTimeoutInMs = -1;
+    private int timesToAttemptInstall = 1;
+
     private ManagedProcessListener listener;
 
     public static DBConfigurationBuilder newBuilder() {
@@ -138,7 +141,7 @@ public class DBConfigurationBuilder {
      * Defines if the configured data and base directories should be deleted on shutdown.
      * If you've set the base and data directories to non temporary directories
      * using {@link #setBaseDir(String)} or {@link #setDataDir(String)},
-     * then they'll also never get deleted anyway. 
+     * then they'll also never get deleted anyway.
      * @param doDelete Default valule is true, set false to override
      * @return returns this
      */
@@ -175,7 +178,25 @@ public class DBConfigurationBuilder {
         frozen = true;
         return new DBConfiguration.Impl(_getPort(), _getSocket(), _getBinariesClassPathLocation(), getBaseDir(), getLibDir(), _getDataDir(),
                 WIN32.equals(getOS()), _getArgs(), _getOSLibraryEnvironmentVarName(), isSecurityDisabled(),
-                isDeletingTemporaryBaseAndDataDirsOnShutdown(), this::getURL, getProcessListener());
+                isDeletingTemporaryBaseAndDataDirsOnShutdown(), this::getURL, getProcessListener(), getInstallationTimeoutInMs(), getTimesToAttemptInstall());
+    }
+
+    public DBConfigurationBuilder setInstallationTimeoutInMs(int installationTimeoutInMs) {
+        this.installationTimeoutInMs = installationTimeoutInMs;
+        return this;
+    }
+
+    private int getInstallationTimeoutInMs() {
+        return installationTimeoutInMs;
+    }
+
+    public int getTimesToAttemptInstall() {
+        return timesToAttemptInstall;
+    }
+
+    public DBConfigurationBuilder setTimesToAttemptInstall(int timesToAttemptInstall) {
+        this.timesToAttemptInstall = timesToAttemptInstall;
+        return this;
     }
 
     /**
@@ -312,5 +333,4 @@ public class DBConfigurationBuilder {
     public List<String> _getArgs() {
         return args;
     }
-
 }

--- a/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/DBTest.java
+++ b/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/DBTest.java
@@ -1,0 +1,92 @@
+package ch.vorburger.mariadb4j;
+
+import ch.vorburger.exec.ManagedProcess;
+import ch.vorburger.exec.ManagedProcessBuilder;
+import ch.vorburger.exec.ManagedProcessException;
+import java.io.IOException;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+
+
+public class DBTest {
+
+  @Test
+  public void testInstallWillOnlyAttemptOneTimeWithMaxWaitTimeIfNotConfigured()
+      throws ManagedProcessException, IOException {
+    // given
+    ManagedProcess mockManagedProcess = new ManagedProcessBuilder("sleep").addArgument("0.01s").build();
+    DB dbSpy = Mockito.spy(new DB(new DBConfigurationBuilder().build()));
+    Mockito.doReturn(mockManagedProcess).when(dbSpy).createMysqlInstallProcess();
+
+    // when
+    dbSpy.install();
+
+    // then
+    Mockito.verify(dbSpy, Mockito.times(0)).attemptToInstallNTimesWithTimeoutInMs(Mockito.anyInt(), Mockito.anyInt());
+  }
+
+  @Test
+  public void testInstallWillOnlyAttemptToLoopInstallationIfConfiguredTo()
+      throws ManagedProcessException, IOException {
+    // given
+    ManagedProcess slowMockManagedProcess = new ManagedProcessBuilder("sleep").addArgument("20s").build();
+    ManagedProcess fastMockManagedProcess = new ManagedProcessBuilder("sleep").addArgument("0.01s").build();
+    DB dbSpy = Mockito.spy(new DB(new DBConfigurationBuilder().setInstallationTimeoutInMs(50).setTimesToAttemptInstall(4).build()));
+    Mockito.doReturn(slowMockManagedProcess) // first return a process that wont finish
+        .doReturn(fastMockManagedProcess) // process will finish now
+        .when(dbSpy).createMysqlInstallProcess();
+
+    // when
+    dbSpy.install();
+
+    // then
+    Mockito.verify(dbSpy, Mockito.times(1)).attemptToInstallNTimesWithTimeoutInMs(Mockito.anyInt(), Mockito.anyInt());
+  }
+
+  @Test
+  public void testInstallWillOnlyAttemptToInstallUntilSuccessful()
+      throws ManagedProcessException, IOException {
+    // given
+    ManagedProcess slowMockManagedProcess = new ManagedProcessBuilder("sleep").addArgument("20s").build();
+    ManagedProcess mediumMockManagedProcessButStillTooSlow = new ManagedProcessBuilder("sleep").addArgument("10s").build();
+    ManagedProcess fastMockManagedProcess = new ManagedProcessBuilder("sleep").addArgument("0.01s").build();
+    DB dbSpy = Mockito.spy(new DB(new DBConfigurationBuilder().build()));
+    Mockito.doReturn(slowMockManagedProcess) // first return a process that wont finish
+        .doReturn(mediumMockManagedProcessButStillTooSlow) // process still wont finish
+        .doReturn(fastMockManagedProcess) // process will finish now
+        .when(dbSpy).createMysqlInstallProcess();
+
+    // when
+    int attempts = dbSpy.attemptToInstallNTimesWithTimeoutInMs(5, 50);
+
+    // then
+    Mockito.verify(dbSpy, Mockito.times(1)).attemptToInstallNTimesWithTimeoutInMs(Mockito.anyInt(), Mockito.anyInt());
+    assertEquals(3, attempts);
+  }
+
+
+  @Test(expected = ManagedProcessException.class)
+  public void testInstallWillOnlyAttemptToInstallTheConfiguredAmountOfTimes()
+      throws ManagedProcessException, IOException {
+    // given
+    ManagedProcess slowMockManagedProcess = new ManagedProcessBuilder("sleep").addArgument("2s").build();
+    ManagedProcess alsoVerySlowMockManagedProcess = new ManagedProcessBuilder("sleep").addArgument("2s").build();
+    ManagedProcess mediumMockManagedProcessButStillTooSlow = new ManagedProcessBuilder("sleep").addArgument("1s").build();
+    DB dbSpy = Mockito.spy(new DB(new DBConfigurationBuilder().setInstallationTimeoutInMs(50).setTimesToAttemptInstall(3).build()));
+    Mockito.doReturn(slowMockManagedProcess) // first return a process that wont finish
+        .doReturn(alsoVerySlowMockManagedProcess) // process still wont finish
+        .doReturn(mediumMockManagedProcessButStillTooSlow) // process still wont finish
+        .when(dbSpy).createMysqlInstallProcess();
+
+    // when
+    try {
+      dbSpy.install();
+    } catch (ManagedProcessException e) {
+      assertEquals("Unable to install mysql after 3 attempts", e.getCause().getMessage());
+      throw e;
+    }
+  }
+
+}

--- a/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
+++ b/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +18,6 @@
  * #L%
  */
 package ch.vorburger.mariadb4j.tests;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,6 +28,9 @@ import org.junit.Test;
 import ch.vorburger.mariadb4j.DBConfiguration;
 import ch.vorburger.mariadb4j.DBConfigurationBuilder;
 import ch.vorburger.mariadb4j.Util;
+
+import static org.junit.Assert.*;
+
 
 public class DBConfigurationBuilderTest {
 
@@ -113,6 +112,30 @@ public class DBConfigurationBuilderTest {
 
         String updatedLibDir = config.getLibDir();
         assertEquals(updatedLibDir, libDir.toAbsolutePath().toString());
+    }
+
+    @Test
+    public void timeoutIsNegativeOneByDefault() {
+        DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+        DBConfiguration build = builder.build();
+        assertEquals(-1, build.getInstallationTimeoutInMs());
+    }
+
+    @Test
+    public void numberOfTimesToAttemptIsOneByDefault() {
+        DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+        DBConfiguration build = builder.build();
+        assertEquals(1, build.getTimesToAttemptInstall());
+    }
+
+    @Test
+    public void timeoutAndNumberOfInstallAttemptsAreBothConfigurable() {
+        DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+        builder.setTimesToAttemptInstall(3);
+        builder.setInstallationTimeoutInMs(20000);
+        DBConfiguration build = builder.build();
+        assertEquals(20000, build.getInstallationTimeoutInMs());
+        assertEquals(3, build.getTimesToAttemptInstall());
     }
 
     @Test

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,10 +32,10 @@ import ch.vorburger.exec.ManagedProcessException;
 
 /**
  * Simulating starting MariaDB4j on all supported platforms.
- * 
+ *
  * <p>This detects the recurring issue of some mariaDB startup script not being where it's expected to
  * be and breaking a platform when upgrading the binaries or making code changes.
- * 
+ *
  * @author Michael Vorburger
  */
 public class StartSimulatedForAllPlatformsTest {
@@ -61,7 +61,7 @@ public class StartSimulatedForAllPlatformsTest {
         db.prepareDirectories();
         db.unpackEmbeddedDb();
 
-        ManagedProcess installProc = db.installPreparation();
+        ManagedProcess installProc = db.createMysqlInstallProcess();
         checkManagedProcessExists(installProc);
 
         ManagedProcess startProc = db.startPreparation();


### PR DESCRIPTION
These are the changes that I have described in: #287 

The mysql installation process has introduced some flakiness into our CI environment, as it can get stuck and take minutes to complete. 

After some extensive debugging, I was unable to pinpoint a specific cause. So a fix with a bit more debugging is to allow for the mysql install script to be "restarted" if it is taking too long, as per configs. 

Unless these configs are applied, existing behavior of waiting for exit remains. 

Also, I have a corresponding change to ch.vorburger.exec here:
https://github.com/vorburger/ch.vorburger.exec/pull/28 that this PR relies upon. 