### PR TITLE
Rename installPreparation method to createMysqlInstallProcess and expose as protected

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -71,7 +71,7 @@ public class DB {
     /**
      * This factory method is the mechanism for constructing a new embedded database for use. This
      * method automatically installs the database and prepares it for use.
-     * 
+     *
      * @param config Configuration of the embedded instance
      * @return a new DB instance
      * @throws ManagedProcessException if something fatal went wrong
@@ -88,7 +88,7 @@ public class DB {
      * This factory method is the mechanism for constructing a new embedded database for use. This
      * method automatically installs the database and prepares it for use with default
      * configuration, allowing only for specifying port.
-     * 
+     *
      * @param port the port to start the embedded database on
      * @return a new DB instance
      * @throws ManagedProcessException if something fatal went wrong
@@ -99,7 +99,7 @@ public class DB {
         return newEmbeddedDB(config.build());
     }
 
-    ManagedProcess installPreparation() throws ManagedProcessException, IOException {
+    protected ManagedProcess createMysqlInstallProcess() throws ManagedProcessException, IOException {
         logger.info("Installing a new embedded database to: " + baseDir);
         File installDbCmdFile = newExecutableFile("bin", "mysql_install_db");
         if (!installDbCmdFile.exists())
@@ -131,12 +131,12 @@ public class DB {
 
     /**
      * Installs the database to the location specified in the configuration.
-     * 
+     *
      * @throws ManagedProcessException if something fatal went wrong
      */
     synchronized protected void install() throws ManagedProcessException {
         try {
-            ManagedProcess mysqlInstallProcess = installPreparation();
+            ManagedProcess mysqlInstallProcess = createMysqlInstallProcess();
             mysqlInstallProcess.start();
             mysqlInstallProcess.waitForExit();
         } catch (Exception e) {
@@ -151,7 +151,7 @@ public class DB {
 
     /**
      * Starts up the database, using the data directory and port specified in the configuration.
-     * 
+     *
      * @throws ManagedProcessException if something fatal went wrong
      */
     public synchronized void start() throws ManagedProcessException {
@@ -239,7 +239,7 @@ public class DB {
      * Config Socket as absolute path. By default this is the case because DBConfigurationBuilder
      * creates the socket in /tmp, but if a user uses setSocket() he may give a relative location,
      * so we double check.
-     * 
+     *
      * @return config.getSocket() as File getAbsolutePath()
      */
     protected File getAbsoluteSocketFile() {
@@ -280,7 +280,7 @@ public class DB {
     /**
      * Takes in a string that represents a resource on the classpath and sources it via the mysql
      * command line tool.
-     * 
+     *
      * @param resource the path to a resource on the classpath to source
      * @param username the username used to login to the database
      * @param password the password used to login to the database
@@ -379,7 +379,7 @@ public class DB {
 
     /**
      * Stops the database.
-     * 
+     *
      * @throws ManagedProcessException if something fatal went wrong
      */
     public synchronized void stop() throws ManagedProcessException {
@@ -420,7 +420,7 @@ public class DB {
     /**
      * If the data directory specified in the configuration is a temporary directory, this deletes
      * any previous version. It also makes sure that the directory exists.
-     * 
+     *
      * @throws ManagedProcessException if something fatal went wrong
      */
     protected void prepareDirectories() throws ManagedProcessException {
@@ -461,12 +461,12 @@ public class DB {
                     logger.warn("cleanupOnExit() ShutdownHook: An error occurred while stopping the database", e);
                 }
 
-                if (dataDir.exists() && (configuration.isDeletingTemporaryBaseAndDataDirsOnShutdown() 
+                if (dataDir.exists() && (configuration.isDeletingTemporaryBaseAndDataDirsOnShutdown()
                                     && Util.isTemporaryDirectory(dataDir.getAbsolutePath()))) {
                     logger.info("cleanupOnExit() ShutdownHook quietly deleting temporary DB data directory: " + dataDir);
                     FileUtils.deleteQuietly(dataDir);
                 }
-                if (baseDir.exists() && (configuration.isDeletingTemporaryBaseAndDataDirsOnShutdown() 
+                if (baseDir.exists() && (configuration.isDeletingTemporaryBaseAndDataDirsOnShutdown()
                                     && Util.isTemporaryDirectory(baseDir.getAbsolutePath()))) {
                     logger.info("cleanupOnExit() ShutdownHook quietly deleting temporary DB base directory: " + baseDir);
                     FileUtils.deleteQuietly(baseDir);

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -165,7 +165,7 @@ public class DB {
             throw new ManagedProcessException("An error occurred while starting the database", e);
         }
         if (!ready) {
-            if (mysqldProcess.isAlive())
+            if (mysqldProcess != null && mysqldProcess.isAlive())
                 mysqldProcess.destroy();
             throw new ManagedProcessException("Database does not seem to have started up correctly? Magic string not seen in "
                     + dbStartMaxWaitInMS + "ms: " + getReadyForConnectionsTag() + mysqldProcess.getLastConsoleLines());
@@ -383,7 +383,7 @@ public class DB {
      * @throws ManagedProcessException if something fatal went wrong
      */
     public synchronized void stop() throws ManagedProcessException {
-        if (mysqldProcess.isAlive()) {
+        if (mysqldProcess != null && mysqldProcess.isAlive()) {
             logger.debug("Stopping the database...");
             mysqldProcess.destroy();
             logger.info("Database stopped.");

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -99,7 +99,7 @@ public class DB {
         return newEmbeddedDB(config.build());
     }
 
-    protected ManagedProcess createMysqlInstallProcess() throws ManagedProcessException, IOException {
+    protected ManagedProcess createDBInstallProcess() throws ManagedProcessException, IOException {
         logger.info("Installing a new embedded database to: " + baseDir);
         File installDbCmdFile = newExecutableFile("bin", "mysql_install_db");
         if (!installDbCmdFile.exists())

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -136,7 +136,7 @@ public class DB {
      */
     synchronized protected void install() throws ManagedProcessException {
         try {
-            ManagedProcess mysqlInstallProcess = createMysqlInstallProcess();
+            ManagedProcess mysqlInstallProcess = createDBInstallProcess();
             mysqlInstallProcess.start();
             mysqlInstallProcess.waitForExit();
         } catch (Exception e) {

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,10 +32,10 @@ import ch.vorburger.exec.ManagedProcessException;
 
 /**
  * Simulating starting MariaDB4j on all supported platforms.
- * 
+ *
  * <p>This detects the recurring issue of some mariaDB startup script not being where it's expected to
  * be and breaking a platform when upgrading the binaries or making code changes.
- * 
+ *
  * @author Michael Vorburger
  */
 public class StartSimulatedForAllPlatformsTest {
@@ -61,7 +61,7 @@ public class StartSimulatedForAllPlatformsTest {
         db.prepareDirectories();
         db.unpackEmbeddedDb();
 
-        ManagedProcess installProc = db.installPreparation();
+        ManagedProcess installProc = db.createMysqlInstallProcess();
         checkManagedProcessExists(installProc);
 
         ManagedProcess startProc = db.startPreparation();

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
@@ -61,7 +61,7 @@ public class StartSimulatedForAllPlatformsTest {
         db.prepareDirectories();
         db.unpackEmbeddedDb();
 
-        ManagedProcess installProc = db.createMysqlInstallProcess();
+        ManagedProcess installProc = db.createDBInstallProcess();
         checkManagedProcessExists(installProc);
 
         ManagedProcess startProc = db.startPreparation();


### PR DESCRIPTION
As per #299 , exposing `installPreparation` (and rename the method to something more appropriate) to allow for subclassing of the `install` method to better suit individual project needs. 