### PR TITLE
Added option to run database scripts less verbose

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -313,7 +313,7 @@ public class DB {
     }
 
     public void run(String command, String username, String password, String dbName) throws ManagedProcessException {
-        run(command, username, password, dbName, false);
+        run(command, username, password, dbName, false, true);
     }
 
     public void run(String command) throws ManagedProcessException {
@@ -325,10 +325,17 @@ public class DB {
     }
 
     public void run(String command, String username, String password, String dbName, boolean force) throws ManagedProcessException {
+        run(command, username, password, dbName, force, true);
+    }
+
+    public void run(String command, String username, String password, String dbName, boolean force, boolean verbose) throws ManagedProcessException {
         // If resource is created here, it should probably be released here also (as opposed to in protected run method)
         // Also move to try-with-resource syntax to remove closeQuietly deprecation errors.
         try (InputStream from = IOUtils.toInputStream(command, Charset.defaultCharset())) {
-            run("command: " + command, from, username, password, dbName, force);
+            final String logInfoText = verbose
+                                       ? "command: " + command
+                                       : "command (" + (command.length() / 1_024) + " KiB long)";
+            run(logInfoText, from, username, password, dbName, force);
         } catch (IOException ioe) {
             logger.warn("Issue trying to close source InputStream. Raise warning and continue.", ioe);
         }


### PR DESCRIPTION
Added an option to run database scripts less verbose. 

This runs fine with all unit tests, as you can see it almost changes nothing in the code!

But: If I create big databases for integration tests, it safes about a minute where it otherwise would scroll seemingly endlessly through the SQL script file content I already know. And without this option my log files are flooded with none-info. I could change the logging level, but all the other info from MariaDB4j is really informative, but not the script file, content I already know re-listed in excruciating detail.

This change is so small that I wouldn't insist on an entry in the contributors.md.