### PR TITLE
Maven Plugins:Fixing typo error

### DIFF
--- a/mariaDB4j-maven-plugin/pom.xml
+++ b/mariaDB4j-maven-plugin/pom.xml
@@ -86,7 +86,7 @@
                 <artifactId>mariaDB4j</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!-- Maven testing includes an older version at a higher level tham mariaDB4j, so including here -->
+            <!-- Maven testing includes an older version at a higher level than mariaDB4j, so including here -->
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>


### PR DESCRIPTION
What i did:
   According to this commit [here](https://github.com/vorburger/MariaDB4j/pull/175/files/509d40b050ac4baa7227cdcf759598479795ee5f#diff-b14ceec598a3b9e47ae43b8a80978e45), i tried to fix a small change in comments, its a small fix which wont cause any harm.
  thanks cc @vorburger 