### PR TITLE
[MariaDB4jService] Do not recreate the DB if already running

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ MariaDB4j CONTRIBUTORS
 - Neelesh Shastry [@neeleshs](https://github.com/neeleshs), Dec 2017 Provide a callback if the DB process crashes
 - Gordon Little [@glittle1972](https://github.com/glittle1972), Jun 2019 Add option to force continue-on-error for sourcing SQL scripts
 - Theodore Ni [@tjni](https://github.com/tjni), Aug 2019 Reduce file copying during classpath unpacking
+- Tamas Gaspar [@tomlincoln](https://github.com/tomlincoln), Oct 2020 Make MariaDB4jService start method do not recreate the DB when already started
 - also see https://github.com/vorburger/MariaDB4j/graphs/contributors
 
 Contributions, patches, forks more than welcome - hack it, and add your name here! ;-)

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/MariaDB4jService.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/MariaDB4jService.java
@@ -49,7 +49,7 @@ public class MariaDB4jService {
     protected DBConfigurationBuilder configBuilder;
 
     public DB getDB() {
-        if (db == null)
+        if (!isRunning())
             throw new IllegalStateException("start() me up first!");
         return db;
     }
@@ -70,6 +70,8 @@ public class MariaDB4jService {
     }
 
     public void start() throws ManagedProcessException {
+        if (isRunning())
+            return;
         db = DB.newEmbeddedDB(getConfiguration().build());
         db.start();
     }


### PR DESCRIPTION
I think the start method should check if already started or not.
If you make the MariaDB4jSpringService bean from a config class, and you run source on it, then after initializing all beans, when PostConstruct is called, it calls start() and _resets_ the DB. I think this is not intentional, so I've added the necessary check.