### PR TITLE
Issue #372: Add automatic module name to core

### DIFF
--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>ch.vorburger.exec</groupId>
             <artifactId>exec</artifactId>
-            <version>3.1.1</version>
+            <version>3.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -59,4 +59,21 @@
 
     </dependencies>
 
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                <archive>
+                    <manifestEntries>
+                        <Automatic-Module-Name>ch.vorburger.mariaDB4j</Automatic-Module-Name>
+                    </manifestEntries>
+                </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -69,7 +69,7 @@
                 <configuration>
                 <archive>
                     <manifestEntries>
-                        <Automatic-Module-Name>ch.vorburger.mariaDB4j</Automatic-Module-Name>
+                        <Automatic-Module-Name>ch.vorburger.mariadb4j</Automatic-Module-Name>
                     </manifestEntries>
                 </archive>
                 </configuration>


### PR DESCRIPTION
Libraries without a set automatic module name causes build warnings for
all clients who build with Java >= 9.

Also bump version of the Exec library, to use a version which has the
automatic module name set.

The following pull request for Exec adds an automatic module name:
https://github.com/vorburger/ch.vorburger.exec/pull/40