### PR TITLE
Adding option to specify os user to the mysqld process

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/springframework/MariaDB4jSpringService.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/springframework/MariaDB4jSpringService.java
@@ -51,6 +51,7 @@ public class MariaDB4jSpringService extends MariaDB4jService implements Lifecycl
     public final static String BASE_DIR = "mariaDB4j.baseDir";
     public final static String LIB_DIR = "mariaDB4j.libDir";
     public final static String UNPACK = "mariaDB4j.unpack";
+    public final static String OS_USER = "mariaDB4j.osUser";
 
     protected ManagedProcessException lastException;
 
@@ -88,6 +89,12 @@ public class MariaDB4jSpringService extends MariaDB4jService implements Lifecycl
     public void setDefaultIsUnpackingFromClasspath(Boolean unpack) {
         if (unpack != null)
             getConfiguration().setUnpackingFromClasspath(unpack);
+    }
+    
+    @Value("${" + OS_USER + ":NA}")
+    public void setDefaultOsUser(String osUser) {
+        if (!"NA".equals(osUser))
+            getConfiguration().addArg("--user=" + osUser);
     }
 
     @Override


### PR DESCRIPTION
When running a service build in drone, I was trying to use mariadb4j as an embedded test database.
It refused to start as drone runs all the processes as root in the container and mysqld complained/refused to start as the user was root.
Found a workaround to specify the os user, to circumvent the problem.
I believe this will be helpful for users who will try to use with springboot in kubernetes environments.