### PR TITLE
mariaDB4j-maven-plugin: exposed database url as Maven Project property

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,51 @@ helpful tool for launching MariaDB from Java.
 
 See pom and integration test in https://github.com/vorburger/MariaDB4j/tree/mariaDB4j-maven-plugin/mariaDB4j-maven-plugin/src/it/mariadb4j-maven-plugin-test-basic  for usage example.
 
+#### Example usage
+
+An example usage of this plugin is to install and start a database at the start of the integration test phase, and stop and uninstall the database afterwards.
+
+This is done by configuring the plugin to execute the `start` goal in the `pre-integration-test` phase and the `stop` goal in the `post-integration-test` phase:
+
+```xml
+<plugin>
+  <groupId>ch.vorburger.mariaDB4j</groupId>
+  <artifactId>mariaDB4j-maven-plugin</artifactId>
+  ...
+  <executions>
+    <execution>
+      <id>pre-integration-test</id>
+      <goals>
+        <goal>start</goal>
+      </goals>
+    </execution>
+    <execution>
+      <id>post-integration-test</id>
+      <goals>
+        <goal>stop</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+```
+
+This will ensure there is a MariaDB instance running on a random port, and expose the database URL as a Maven Project property.
+
+To access the database in your integration tests, you can pass the database URL as system property to your integration tests:
+
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-failsafe-plugin</artifactId>
+  ...
+  <configuration>
+    <systemProperties>
+      <mariadb.databaseurl>${mariadb4j.databaseurl}</mariadb.databaseurl>
+    </systemProperties>
+  </configuration>
+</plugin>
+```
+
 #### How to upgrade the maven plugin from mike10004 version to this version
 
 To upgrade from mike10004 to vorbuger version please change

--- a/mariaDB4j-maven-plugin/src/it/mariadb4j-maven-plugin-test-basic/pom.xml
+++ b/mariaDB4j-maven-plugin/src/it/mariadb4j-maven-plugin-test-basic/pom.xml
@@ -49,6 +49,7 @@
                     <systemPropertyVariables>
                         <mariadb4j.port>${mariadb4j.port}</mariadb4j.port>
                         <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+                        <mariadb.databaseurl>${mariadb4j.databaseurl}</mariadb.databaseurl>
                     </systemPropertyVariables>
                 </configuration>
                 <executions>

--- a/mariaDB4j-maven-plugin/src/it/mariadb4j-maven-plugin-test-basic/src/test/java/ch/vorburger/mariadb4j/mariadb4jmavenplugintest/basic/BasicUsageIT.java
+++ b/mariaDB4j-maven-plugin/src/it/mariadb4j-maven-plugin-test-basic/src/test/java/ch/vorburger/mariadb4j/mariadb4jmavenplugintest/basic/BasicUsageIT.java
@@ -40,6 +40,7 @@ public class BasicUsageIT {
         int port = Integer.parseInt(System.getProperty("mariadb4j.port"));
         assertTrue("expect positive port value: " + port, port > 0);
         String jdbcUrl = "jdbc:mysql://localhost:" + port + "/foo";
+        assertEquals("database url in system properties", jdbcUrl, System.getProperty("mariadb.databaseurl"));
         try (Connection conn = DriverManager.getConnection(jdbcUrl)) {
             try (Statement stmt = conn.createStatement();
                 ResultSet rs = stmt.executeQuery("SHOW TABLES LIKE 'bar'")) {

--- a/mariaDB4j-maven-plugin/src/main/java/ch/vorburger/mariadb4j/AbstractRunMojo.java
+++ b/mariaDB4j-maven-plugin/src/main/java/ch/vorburger/mariadb4j/AbstractRunMojo.java
@@ -181,4 +181,8 @@ public abstract class AbstractRunMojo extends AbstractMojo {
     public String getDatabaseName() {
         return databaseName;
     }
+
+    protected final MavenProject getProject() {
+        return project;
+    }
 }

--- a/mariaDB4j-maven-plugin/src/main/java/ch/vorburger/mariadb4j/StartMojo.java
+++ b/mariaDB4j-maven-plugin/src/main/java/ch/vorburger/mariadb4j/StartMojo.java
@@ -43,6 +43,8 @@ import java.io.IOException;
         requiresDependencyResolution = ResolutionScope.TEST)
 public class StartMojo extends AbstractRunMojo {
 
+    private static final String PROPNAME_DATABASE_URL = "mariadb4j.databaseurl";
+
     @Override
     protected void runWithMavenJvm(DBConfigurationBuilder configurationBuilder) throws MojoExecutionException {
         try {
@@ -58,7 +60,10 @@ public class StartMojo extends AbstractRunMojo {
             }
             this.runScripts(db, databaseName);
 
-            getLog().warn("Database started and is configured on " + DBSingleton.getConfigurationBuilder().getURL(databaseName));
+            String databaseURL = DBSingleton.getConfigurationBuilder().getURL(databaseName);
+            getProject().getProperties().setProperty(PROPNAME_DATABASE_URL, databaseURL);
+
+            getLog().warn("Database started and is configured on " + databaseURL);
         } catch (ManagedProcessException ex) {
             throw new MojoExecutionException(
                     "Could not setup, start database", ex);

--- a/mariaDB4j-maven-plugin/src/test/java/ch/vorburger/mariaDB4j/Mariadb4jStartMojoTest.java
+++ b/mariaDB4j-maven-plugin/src/test/java/ch/vorburger/mariaDB4j/Mariadb4jStartMojoTest.java
@@ -99,7 +99,7 @@ public class Mariadb4jStartMojoTest {
         File pom = new File(getClass().getResource( "/basic-usage/pom.xml").toURI());
         assertThat(pom.isFile()).overridingErrorMessage( "not found: %s", pom).isTrue();
         assertThat(pom.exists()).isTrue();
-        StartMojo mojo = (StartMojo) mojoRule.lookupMojo("start", pom);
+        StartMojo mojo = (StartMojo) mojoRule.lookupConfiguredMojo(pom.getParentFile(), "start");
         assertThat(mojo).isNotNull();
         pluginContext = mojo.getPluginContext();
         if (pluginContext == null) {
@@ -153,7 +153,7 @@ public class Mariadb4jStartMojoTest {
     public void utf8mb4() throws Exception {
         File pom = new File(getClass().getResource( "/utf8mb4/pom.xml").toURI());
         assertThat(pom.isFile()).overridingErrorMessage( "not found: %s", pom).isTrue();
-        StartMojo mojo = (StartMojo) mojoRule.lookupMojo("start", pom);
+        StartMojo mojo = (StartMojo) mojoRule.lookupConfiguredMojo(pom.getParentFile(), "start");
         assertThat(mojo).isNotNull();
         pluginContext = mojo.getPluginContext();
         if (pluginContext == null) {


### PR DESCRIPTION
There is currently no way to know on which port the `mariaDB4j-maven-plugin` has started the database so that integration tests can connect to it.
The only option is to hardcode a port number in the configuration of the `mariaDB4j-maven-plugin`, and use that same hardcoded port number in your test.

The old plugin version from mike10004 exposed a port number as Maven Project property (see [this file](https://github.com/mike10004/mariadb4j-maven-plugin/blob/master/mariadb4j-maven-plugin/src/main/java/com/github/mike10004/mariadb4jmavenplugin/Mariadb4jFindFreePortMojo.java)).

This PR does more or less the same. Instead of exposing the port number, it exposes the database URL. I also updated the readme to show how to retrieve that database URL and pass it to your integration tests as system property.