### PR TITLE
Run mvn verify instead of only package on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ before_install:
 # TODO uncomment this when raising a PR to fix https://github.com/vorburger/MariaDB4j/issues/484
 #  - mvn -f DBs/pom.xml clean install
 
-script: mvn package -B -V
+# Run verify, not just package, to catch any failures of mariaDB4j-maven-plugin's integration test
+script: mvn verify -B -V


### PR DESCRIPTION
Originally motivated by #488 (but then found to actually be unrelated to that - but still a good idea).