### PR TITLE
Remove fixed version of commons-io from Maven plugin dependencies

### DIFF
--- a/mariaDB4j-maven-plugin/pom.xml
+++ b/mariaDB4j-maven-plugin/pom.xml
@@ -86,12 +86,6 @@
                 <artifactId>mariaDB4j</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!-- Maven testing includes an older version at a higher level than mariaDB4j, so including here -->
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-artifact</artifactId>


### PR DESCRIPTION
This doesn't fix https://github.com/vorburger/MariaDB4j/issues/488,
but still seems like a good idea to do, because the currently used
Maven version (or that test dependency) seems to use IO 2.4.1 as
well, so this does not appear to be required anymore now.
