### PR TITLE
When dumping the database, close the outputstream once the dump is done

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -19,8 +19,11 @@
  */
 package ch.vorburger.mariadb4j;
 
-import ch.vorburger.exec.*;
-
+import ch.vorburger.exec.ManagedProcess;
+import ch.vorburger.exec.ManagedProcessBuilder;
+import ch.vorburger.exec.ManagedProcessException;
+import ch.vorburger.exec.ManagedProcessListener;
+import ch.vorburger.exec.OutputStreamLogDispatcher;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -516,10 +519,11 @@ public class DB {
                 closeOutputStream();
             }
 
-            private void closeOutputStream(){
+            private void closeOutputStream() {
                 try {
                     outputStream.close();
-                } catch (IOException ignore) {
+                } catch (IOException exception) {
+                    logger.error("Problem while trying to close the stream to the file containing the DB dump", exception);
                 }
             }
         });


### PR DESCRIPTION
This should fix #340 .

The created outputstream is now closed using a process listener, which should get triggered when the dump is either done or has failed.

Alas, no test in this commit.

- I couldn't find any existing tests that perform a dump
- Even if there would be such a test, I would not know how to check from Java code whether that file stream is closed, unless I added some ugly code to grant me access to that stream

If you really want to have a test for this, some pointers in how you would approach testing this are welcome