### PR TITLE
Bump ch.vorburger.exec to 3.1.3 (fixes #501)

### DIFF
--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>ch.vorburger.exec</groupId>
             <artifactId>exec</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
for https://github.com/vorburger/ch.vorburger.exec/pull/60
and https://github.com/vorburger/ch.vorburger.exec/pull/58

see https://github.com/vorburger/MariaDB4j/issues/501