### PR TITLE
Support default character set configuration.

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -195,6 +195,9 @@ public class DB {
         for (String arg : configuration.getArgs()) {
             builder.addArgument(arg);
         }
+        if (StringUtils.isNotBlank(configuration.getDefaultCharacterSet())) {
+            builder.addArgument("--character-set-server=", configuration.getDefaultCharacterSet());
+        }
         cleanupOnExit();
         // because cleanupOnExit() just installed our (class DB) own
         // Shutdown hook, we don't need the one from ManagedProcess:
@@ -362,6 +365,9 @@ public class DB {
             }
             if (configuration.getProcessListener() != null) {
                 builder.setProcessListener(configuration.getProcessListener());
+            }
+            if (configuration.getDefaultCharacterSet() != null) {
+                builder.addArgument("--default-character-set=", configuration.getDefaultCharacterSet());
             }
 
             ManagedProcess process = builder.build();

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
@@ -94,6 +94,8 @@ public interface DBConfiguration {
 
     String getURL(String dbName);
 
+    String getDefaultCharacterSet();
+
     static class Impl implements DBConfiguration {
 
         private final int port;
@@ -106,13 +108,15 @@ public interface DBConfiguration {
         private final boolean isWindows;
         private final List<String> args;
         private final String osLibraryEnvironmentVarName;
+        private String defaultCharacterSet;
         private final ManagedProcessListener listener;
         private final boolean isSecurityDisabled;
         private final Function<String, String> getURL;
 
         Impl(int port, String socket, String binariesClassPathLocation, String baseDir, String libDir, String dataDir,
              boolean isWindows, List<String> args, String osLibraryEnvironmentVarName, boolean isSecurityDisabled,
-             boolean isDeletingTemporaryBaseAndDataDirsOnShutdown, Function<String, String> getURL, ManagedProcessListener listener) {
+             boolean isDeletingTemporaryBaseAndDataDirsOnShutdown, Function<String, String> getURL,
+             String defaultCharacterSet, ManagedProcessListener listener) {
             super();
             this.port = port;
             this.socket = socket;
@@ -126,6 +130,7 @@ public interface DBConfiguration {
             this.osLibraryEnvironmentVarName = osLibraryEnvironmentVarName;
             this.isSecurityDisabled = isSecurityDisabled;
             this.getURL = getURL;
+            this.defaultCharacterSet = defaultCharacterSet;
             this.listener = listener;
         }
 
@@ -192,6 +197,15 @@ public interface DBConfiguration {
         @Override
         public ManagedProcessListener getProcessListener() {
             return listener;
+        }
+
+        @Override
+        public String getDefaultCharacterSet() {
+            return defaultCharacterSet;
+        }
+
+        public void setDefaultCharacterSet(String defaultCharacterSet) {
+            this.defaultCharacterSet = defaultCharacterSet;
         }
     }
 

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -23,6 +23,7 @@ import ch.vorburger.exec.ManagedProcessListener;
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.SystemUtils;
@@ -56,6 +57,8 @@ public class DBConfigurationBuilder {
 
     private boolean frozen = false;
     private ManagedProcessListener listener;
+
+    protected String defaultCharacterSet = null;
 
     public static DBConfigurationBuilder newBuilder() {
         return new DBConfigurationBuilder();
@@ -176,7 +179,7 @@ public class DBConfigurationBuilder {
         frozen = true;
         return new DBConfiguration.Impl(_getPort(), _getSocket(), _getBinariesClassPathLocation(), getBaseDir(), getLibDir(), _getDataDir(),
                 WIN32.equals(getOS()), _getArgs(), _getOSLibraryEnvironmentVarName(), isSecurityDisabled(),
-                isDeletingTemporaryBaseAndDataDirsOnShutdown(), this::getURL, getProcessListener());
+                isDeletingTemporaryBaseAndDataDirsOnShutdown(), this::getURL, getDefaultCharacterSet(), getProcessListener());
     }
 
     /**
@@ -314,4 +317,11 @@ public class DBConfigurationBuilder {
         return args;
     }
 
+    public void setDefaultCharacterSet(String defaultCharacterSet) {
+        this.defaultCharacterSet = defaultCharacterSet;
+    }
+
+    public String getDefaultCharacterSet() {
+        return defaultCharacterSet;
+    }
 }

--- a/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
+++ b/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
@@ -21,6 +21,7 @@ package ch.vorburger.mariadb4j.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import ch.vorburger.mariadb4j.DBConfiguration;
@@ -117,5 +118,21 @@ public class DBConfigurationBuilderTest {
         builder.setDeletingTemporaryBaseAndDataDirsOnShutdown(false);
         DBConfiguration config = builder.build();
         assertFalse(config.isDeletingTemporaryBaseAndDataDirsOnShutdown());
+    }
+
+    @Test public void defaultCharacterSet() {
+        DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+        String character = "utf8mb4";
+        builder.setDefaultCharacterSet(character);
+        DBConfiguration config = builder.build();
+        String defaultCharacterSet = config.getDefaultCharacterSet();
+        assertEquals(character, defaultCharacterSet);
+    }
+
+    @Test public void defaultCharacterSetIsEmpty() {
+        DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+        DBConfiguration config = builder.build();
+        String defaultCharacterSet = config.getDefaultCharacterSet();
+        assertNull(defaultCharacterSet);
     }
 }

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleOtherTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleOtherTest.java
@@ -87,4 +87,15 @@ public class MariaDB4jSampleOtherTest {
         db.stop();
     }
 
+    @Test public void customCharacterSet() throws Exception {
+        DBConfigurationBuilder config = DBConfigurationBuilder.newBuilder();
+        config.setBaseDir(SystemUtils.JAVA_IO_TMPDIR + "/MariaDB4j/" + MariaDB4jSampleOtherTest.class.getName() + "customBaseDir");
+        config.setDefaultCharacterSet("utf8mb4");
+        DB db = DB.newEmbeddedDB(config.build());
+        db.start();
+        db.createDB("junittest");
+        db.source("ch/vorburger/mariadb4j/characterTest.sql");
+        db.stop();
+    }
+
 }

--- a/mariaDB4j/src/test/resources/ch/vorburger/mariadb4j/characterTest.sql
+++ b/mariaDB4j/src/test/resources/ch/vorburger/mariadb4j/characterTest.sql
@@ -1,0 +1,9 @@
+use junittest;
+
+CREATE TABLE test(
+  id int PRIMARY KEY AUTO_INCREMENT,
+  name varchar(255) NOT NULL
+);
+
+
+INSERT INTO test (name) VALUES ('测试（字符集）');


### PR DESCRIPTION
Hi, I add default character set option in configuration. 
I know the addArgument function, but this action only effect with server side. 

When you want run script as another character set, "addArgument" function will doesn't work.