### PR TITLE
Remove wrong space from DYLD_FALLBACK_LIBRARY_PATH

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -284,7 +284,7 @@ public class DBConfigurationBuilder {
     }
 
     protected String _getOSLibraryEnvironmentVarName() {
-        return SystemUtils.IS_OS_WINDOWS ? "PATH" : SystemUtils.IS_OS_MAC ? "DYLD_FALLBACK_LIBRARY_PATH " : "LD_LIBRARY_PATH";
+        return SystemUtils.IS_OS_WINDOWS ? "PATH" : SystemUtils.IS_OS_MAC ? "DYLD_FALLBACK_LIBRARY_PATH" : "LD_LIBRARY_PATH";
     }
 
     protected String _getBinariesClassPathLocation() {


### PR DESCRIPTION
The Mac specific environment variable `DYLD_FALLBACK_LIBRARY_PATH` probably (?) should not end in space.

Does anyone using MariaDB4j on Mac want to test this?

I stumbled accross this while looking into #560.