### PR TITLE
Add configurable tmpdir

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfiguration.java
@@ -70,6 +70,13 @@ public interface DBConfiguration {
     String getDataDir();
 
     /**
+     * Directory for DB's temporary files.
+     *
+     * @return returns temporary directory value
+     **/
+    String getTmpDir();
+
+    /**
      * Whether to delete the base and data directory on shutdown,
      * if it is in a temporary directory. NB: If you've set the
      * base and data directories to non temporary directories,
@@ -122,6 +129,7 @@ public interface DBConfiguration {
         private final String baseDir;
         private final String libDir;
         private final String dataDir;
+        private final String tmpDir;
         private final boolean isDeletingTemporaryBaseAndDataDirsOnShutdown;
         private final boolean isWindows;
         private final List<String> args;
@@ -132,8 +140,8 @@ public interface DBConfiguration {
         private final Function<String, String> getURL;
         private final Map<Executable, Supplier<File>> executables;
 
-        Impl(int port, String socket, String binariesClassPathLocation, String baseDir, String libDir, String dataDir, boolean isWindows,
-                List<String> args, String osLibraryEnvironmentVarName, boolean isSecurityDisabled,
+        Impl(int port, String socket, String binariesClassPathLocation, String baseDir, String libDir, String dataDir, String tmpDir,
+                boolean isWindows, List<String> args, String osLibraryEnvironmentVarName, boolean isSecurityDisabled,
                 boolean isDeletingTemporaryBaseAndDataDirsOnShutdown, Function<String, String> getURL, String defaultCharacterSet,
                 Map<Executable, Supplier<File>> executables, ManagedProcessListener listener) {
             this.port = port;
@@ -142,6 +150,7 @@ public interface DBConfiguration {
             this.baseDir = baseDir;
             this.libDir = libDir;
             this.dataDir = dataDir;
+            this.tmpDir = tmpDir;
             this.isDeletingTemporaryBaseAndDataDirsOnShutdown = isDeletingTemporaryBaseAndDataDirsOnShutdown;
             this.isWindows = isWindows;
             this.args = args;
@@ -175,6 +184,10 @@ public interface DBConfiguration {
 
         @Override public String getDataDir() {
             return dataDir;
+        }
+
+        @Override public String getTmpDir() {
+            return tmpDir;
         }
 
         @Override public boolean isDeletingTemporaryBaseAndDataDirsOnShutdown() {

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -49,6 +49,8 @@ public class DBConfigurationBuilder {
 
     private static final String DEFAULT_DATA_DIR = SystemUtils.JAVA_IO_TMPDIR + "/MariaDB4j/data";
 
+    private static final String DEFAULT_TMP_DIR = SystemUtils.JAVA_IO_TMPDIR + "/MariaDB4j/tmp";
+
     private String databaseVersion = null;
 
     // all these are just some defaults
@@ -57,6 +59,7 @@ public class DBConfigurationBuilder {
     protected String libDir = null;
 
     protected String dataDir = DEFAULT_DATA_DIR;
+    protected String tmpDir = DEFAULT_TMP_DIR;
     protected String socket = null; // see _getSocket()
     protected int port = 0;
     protected boolean isDeletingTemporaryBaseAndDataDirsOnShutdown = true;
@@ -113,6 +116,16 @@ public class DBConfigurationBuilder {
     public DBConfigurationBuilder setDataDir(String dataDir) {
         checkIfFrozen("setDataDir");
         this.dataDir = dataDir;
+        return this;
+    }
+
+    public String getTmpDir() {
+        return tmpDir;
+    }
+
+    public DBConfigurationBuilder setTmpDir(String tmpDir) {
+        checkIfFrozen("setTmpDir");
+        this.tmpDir = tmpDir;
         return this;
     }
 
@@ -192,7 +205,7 @@ public class DBConfigurationBuilder {
     public DBConfiguration build() {
         frozen = true;
         return new DBConfiguration.Impl(_getPort(), _getSocket(), _getBinariesClassPathLocation(), getBaseDir(), getLibDir(), _getDataDir(),
-                isWindows(), _getArgs(), _getOSLibraryEnvironmentVarName(), isSecurityDisabled(),
+                _getTmpDir(), isWindows(), _getArgs(), _getOSLibraryEnvironmentVarName(), isSecurityDisabled(),
                 isDeletingTemporaryBaseAndDataDirsOnShutdown(), this::getURL, getDefaultCharacterSet(), _getExecutables(),
                 getProcessListener());
     }
@@ -224,6 +237,13 @@ public class DBConfigurationBuilder {
             return DEFAULT_DATA_DIR + File.separator + getPort();
         }
         return getDataDir();
+    }
+
+    protected String _getTmpDir() {
+        if (isNull(getTmpDir()) || getTmpDir().equals(DEFAULT_TMP_DIR)) {
+            return DEFAULT_TMP_DIR + File.separator + getPort();
+        }
+        return getTmpDir();
     }
 
     protected boolean isNull(String string) {

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/springframework/MariaDB4jSpringService.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/springframework/MariaDB4jSpringService.java
@@ -47,6 +47,7 @@ public class MariaDB4jSpringService extends MariaDB4jService implements Lifecycl
     public final static String PORT = "mariaDB4j.port";
     public final static String SOCKET = "mariaDB4j.socket";
     public final static String DATA_DIR = "mariaDB4j.dataDir";
+    public final static String TMP_DIR = "mariaDB4j.tmpDir";
     public final static String BASE_DIR = "mariaDB4j.baseDir";
     public final static String LIB_DIR = "mariaDB4j.libDir";
     public final static String UNPACK = "mariaDB4j.unpack";
@@ -70,6 +71,12 @@ public class MariaDB4jSpringService extends MariaDB4jService implements Lifecycl
     public void setDefaultDataDir(String dataDir) {
         if (!"NA".equals(dataDir))
             getConfiguration().setDataDir(dataDir);
+    }
+
+    @Value("${" + TMP_DIR + ":NA}")
+    public void setDefaultTmpDir(String tmpDir) {
+        if (!"NA".equals(tmpDir))
+            getConfiguration().setTmpDir(tmpDir);
     }
 
     @Value("${" + BASE_DIR + ":NA}")

--- a/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
+++ b/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
@@ -78,6 +78,48 @@ public class DBConfigurationBuilderTest {
         assertTrue(defaultDataDir.contains(Integer.toString(port)));
     }
 
+    @Test public void defaultTmpDirIsTemporaryAndIncludesPortNumber() {
+        DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+        DBConfiguration config = builder.build();
+        String defaultTmpDir = config.getTmpDir();
+        assertTrue(Util.isTemporaryDirectory(defaultTmpDir));
+        int port = config.getPort();
+        assertTrue(defaultTmpDir.contains(Integer.toString(port)));
+    }
+
+    @Test public void defaultTmpDirIsTemporaryAndIncludesPortNumberEvenIfPortIsExplicitlySet() {
+        DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+        builder.setPort(12345);
+        DBConfiguration config = builder.build();
+        String defaultTmpDir = config.getTmpDir();
+        assertTrue(Util.isTemporaryDirectory(defaultTmpDir));
+        assertTrue(defaultTmpDir.contains(Integer.toString(12345)));
+    }
+
+    @Test public void tmpDirDoesNotIncludePortNumberEvenItsExplicitlySet() {
+        DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+        builder.setTmpDir("db/tmp");
+        DBConfiguration config = builder.build();
+        String defaultTmpDir = config.getTmpDir();
+        assertEquals("db/tmp", defaultTmpDir);
+        assertFalse(Util.isTemporaryDirectory(defaultTmpDir));
+    }
+
+    @Test public void resetTmpDirToDefaultTemporary() {
+        DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
+        builder.setTmpDir("db/tmp");
+        assertEquals("db/tmp", builder.getTmpDir());
+        builder.setTmpDir(null);
+        assertEquals(null, builder.getTmpDir());
+        builder.setTmpDir("null");
+        assertEquals("null", builder.getTmpDir());
+        DBConfiguration config = builder.build();
+        String defaultTmpDir = config.getTmpDir();
+        assertTrue(Util.isTemporaryDirectory(defaultTmpDir));
+        int port = config.getPort();
+        assertTrue(defaultTmpDir.contains(Integer.toString(port)));
+    }
+
     @Test public void defaultLibDirIsRelativeToBaseDir() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         DBConfiguration config = builder.build();

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceOverrideBySpringValueTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceOverrideBySpringValueTest.java
@@ -47,6 +47,7 @@ public class MariaDB4jSpringServiceOverrideBySpringValueTest {
             properties.setProperty(MariaDB4jSpringService.BASE_DIR, "target/MariaDB4jSpringServiceOverrideBySpringValueTest/baseDir");
             properties.setProperty(MariaDB4jSpringService.LIB_DIR, "target/MariaDB4jSpringServiceOverrideBySpringValueTest/baseDir/libs");
             properties.setProperty(MariaDB4jSpringService.DATA_DIR, "target/MariaDB4jSpringServiceOverrideBySpringValueTest/dataDir");
+            properties.setProperty(MariaDB4jSpringService.TMP_DIR, "target/MariaDB4jSpringServiceOverrideBySpringValueTest/tmpDir");
         }
     }
 
@@ -59,6 +60,7 @@ public class MariaDB4jSpringServiceOverrideBySpringValueTest {
         assertEquals("target/MariaDB4jSpringServiceOverrideBySpringValueTest/baseDir", s.getConfiguration().getBaseDir());
         assertEquals("target/MariaDB4jSpringServiceOverrideBySpringValueTest/baseDir/libs", s.getConfiguration().getLibDir());
         assertEquals("target/MariaDB4jSpringServiceOverrideBySpringValueTest/dataDir", s.getConfiguration().getDataDir());
+        assertEquals("target/MariaDB4jSpringServiceOverrideBySpringValueTest/tmpDir", s.getConfiguration().getTmpDir());
     }
 
 }

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceStandardDefaultsTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceStandardDefaultsTest.java
@@ -47,6 +47,7 @@ public class MariaDB4jSpringServiceStandardDefaultsTest {
         assertNotEquals(3306, s.getConfiguration().getPort());
         assertTrue(s.getConfiguration().getBaseDir().contains(SystemUtils.JAVA_IO_TMPDIR));
         assertTrue(s.getConfiguration().getDataDir().contains(SystemUtils.JAVA_IO_TMPDIR));
+        assertTrue(s.getConfiguration().getTmpDir().contains(SystemUtils.JAVA_IO_TMPDIR));
     }
 
 }


### PR DESCRIPTION
This makes `--tmpdir` configurable, defaulting to `$TMPDIR/MariaDB4j/tmp/$PORT`. It should solve the issue of running multiple `mysqld` instances in parallel. See #602 for more details.