### PR TITLE
Update springboot version to 2.7.4

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -338,7 +338,7 @@ public class DBConfigurationBuilder {
     }
 
     public String getURL(String databaseName) {
-        return "jdbc:mysql://localhost:" + getPort() + "/" + databaseName;
+        return "jdbc:mariadb://localhost:" + getPort() + "/" + databaseName;
     }
 
     public List<String> _getArgs() {

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
 	<properties>
 		 <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		 <springboot.version>2.6.6</springboot.version>
+		 <springboot.version>2.7.4</springboot.version>
 		 <maven.compiler.source>11</maven.compiler.source>
 		 <maven.compiler.target>11</maven.compiler.target>
 	</properties>


### PR DESCRIPTION
Supersedes and closes #619.

@vorburger I think the error in #619 happened because springboot v2.7.0 [introduced a dependency on `flyway-mysql`](https://github.com/spring-projects/spring-boot/commit/4166429fd0d462d8a1948c77942477af624749b3), so the presence of both that and the mariadb driver on the classpath caused errors:

```
No suitable driver found for jdbc:mysql://localhost:36555/...
```

Updating the connection URL to use `mariadb` instead of `mysql` fixes it -- https://mariadb.com/kb/en/about-mariadb-connector-j/#jdbcmysql-scheme-compatibility