### PR TITLE
Removing `--tmpdir` argument from `mysql_install_db` as it's used in `mysqld`

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -114,7 +114,6 @@ public class DB {
         builder.setWorkingDirectory(baseDir);
         if (!configuration.isWindows()) {
             builder.addFileArgument("--datadir", dataDir);
-            builder.addFileArgument("--tmpdir", tmpDir);
             builder.addFileArgument("--basedir", baseDir);
             builder.addArgument("--no-defaults");
             builder.addArgument("--force");
@@ -122,7 +121,6 @@ public class DB {
             // builder.addArgument("--verbose");
         } else {
             builder.addFileArgument("--datadir", dataDir.getCanonicalFile());
-            builder.addFileArgument("--tmpdir", tmpDir.getCanonicalFile());
         }
         return builder.build();
     }


### PR DESCRIPTION
Resolving https://github.com/vorburger/MariaDB4j/issues/632 and https://github.com/vorburger/MariaDB4j/issues/634