### PR TITLE
PR-689 - Bump springboot.version from 2.7.5 to 3.0.4

### DIFF
--- a/mariaDB4j-app/src/main/java/ch/vorburger/mariadb4j/springframework/boot/MariaDB4jApplication.java
+++ b/mariaDB4j-app/src/main/java/ch/vorburger/mariadb4j/springframework/boot/MariaDB4jApplication.java
@@ -20,6 +20,8 @@
 package ch.vorburger.mariadb4j.springframework.boot;
 
 import ch.vorburger.mariadb4j.MariaDB4jService;
+import ch.vorburger.mariadb4j.springboot.autoconfigure.DataSourceAutoConfiguration;
+import ch.vorburger.mariadb4j.springboot.autoconfigure.MariaDB4jSpringConfiguration;
 import ch.vorburger.mariadb4j.springframework.MariaDB4jSpringService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.Banner.Mode;
@@ -28,6 +30,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * Spring Boot based MariaDB4j main() "Application" launcher.
@@ -37,6 +40,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @EnableAutoConfiguration
+@Import({ DataSourceAutoConfiguration.class, MariaDB4jSpringConfiguration.class })
 public class MariaDB4jApplication implements ExitCodeGenerator {
 
     private final MariaDB4jSpringService mariaDB4j;

--- a/mariaDB4j-springboot/src/main/resources/META-INF/spring.factories
+++ b/mariaDB4j-springboot/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  ch.vorburger.mariadb4j.springboot.autoconfigure.MariaDB4jSpringConfiguration,\
-  ch.vorburger.mariadb4j.springboot.autoconfigure.DataSourceAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<springboot.version>2.7.5</springboot.version>
+		<springboot.version>3.0.4</springboot.version>
 		<jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Bump spring boot version to 3.0.4 . The main change was the removal of spring.factories in spring boot 3.X which i migrated to @Import in MariaDB4jApplication