### PR TITLE
Initial working pass of MariaDB 10.6.12...

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@ MariaDB4j CONTRIBUTORS
 - Gordon Little [@glittle1972](https://github.com/glittle1972), Jun 2019 Add option to force continue-on-error for sourcing SQL scripts
 - Theodore Ni [@tjni](https://github.com/tjni), Aug 2019 Reduce file copying during classpath unpacking
 - Tamas Gaspar [@tomlincoln](https://github.com/tomlincoln), Oct 2020 Make MariaDB4jService start method do not recreate the DB when already started
+- Knowles Atchison, Jr [@TheKnowles](https://github.com/TheKnowles), March 2023 Added MariaDB 10.6.12 to build
 - also see https://github.com/vorburger/MariaDB4j/graphs/contributors
 
 Contributions, patches, forks more than welcome - hack it, and add your name here! ;-)

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/pom.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ch.vorburger.mariaDB4j</groupId>
+        <artifactId>mariaDB4j-pom-lite</artifactId>
+        <version>2.2.1</version>
+        <relativePath>../../mariaDB4j-pom-lite/pom.xml</relativePath>
+    </parent>
+
+	<artifactId>mariaDB4j-db-linux64</artifactId>
+	<version>10.6.12</version>
+
+    <properties>
+        <mariaDB.version>${project.version}</mariaDB.version>
+        <cacheDir>${project.basedir}/../../../tmpDir</cacheDir>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.build.directory}/generated-resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>generate-resources</id>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <target>
+                                <property name="project.basedir" value="${project.basedir}"/>
+                                <property name="project.build.directory" value="${project.build.directory}"/>
+                                <property name="cacheDir" value="${cacheDir}"/>
+                                <property name="mariaDB.version" value="${mariaDB.version}"/>
+                                <ant antfile="${project.basedir}/prepare.xml">
+                                </ant>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>                                 
+        </plugins>
+    </build>
+</project>

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/prepare.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-linux64-10.6.12/prepare.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<project name="MariaDB4J" default="extract" >
+    <description>
+        Ant task to download file from internet and extract during maven package
+    </description>
+
+    <target name="env">
+        <echo message="Project path   : ${project.basedir}"/>
+        <echo message="Output location: ${project.build.directory}"/>
+        <echo message="Cache location : ${cacheDir}"/>
+        <echo message="MariaDB version: ${mariaDB.version}"/>
+        <mkdir dir="${cacheDir}" />
+        <mkdir dir="${cacheDir}/input" />
+    </target>
+
+    <target name="download" depends="env"
+        description="Download linux tar.gz file from mariadb.com">
+        <echo message="Downloading linux MariaDB ${mariaDB.version} file ..." />
+        <get src="https://dlm.mariadb.com/2830105/MariaDB/mariadb-${mariaDB.version}/bintar-linux-systemd-x86_64/mariadb-${mariaDB.version}-linux-systemd-x86_64.tar.gz"
+            skipexisting="true"             
+            dest="${cacheDir}/input/mariadb-${mariaDB.version}-linux-x86_64.tar.gz" />
+    </target>
+
+    <target name="extract" depends="env,download"
+        description="Extract project files">
+        <echo message="Extracting tar.gz file" />
+        <untar src="${cacheDir}/input/mariadb-${mariaDB.version}-linux-x86_64.tar.gz" 
+                dest="${project.build.directory}"
+                compression="gzip"  />
+        <echo message="Copying share folders and files" />
+        <copy todir="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux">
+            <fileset dir="${project.build.directory}/mariadb-${mariaDB.version}-linux-systemd-x86_64">
+                <include name="share/**/*"/>
+            </fileset>
+        </copy>
+        <echo message="Copying lib files" />
+        <copy todir="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux/libs">
+            <fileset dir="${project.build.directory}/mariadb-${mariaDB.version}-linux-systemd-x86_64/lib">
+                <include name="libmariadb.so*"/>
+                <include name="libmariadbclient*"/>
+                <include name="libmysql*"/>
+            </fileset>
+        </copy>
+        <!--- As of MariaDB 10.5.2, the original mysql* bins are sym links to mariadb equivalents.
+        Sym links do not work in jar files as they are not platform independent
+        We copy over the mariadb* names and the code has been updated to use these new binaries
+        https://jira.mariadb.org/browse/MDEV-21303
+        -->
+        <echo message="Copying bin files" />
+        <copy todir="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux/bin">
+            <fileset dir="${project.build.directory}/mariadb-${mariaDB.version}-linux-systemd-x86_64/bin">
+                <include name="mariadb"/>
+                <include name="mariadbd"/>
+                <include name="mariadb-check"/>
+                <include name="mariadb-dump"/>
+                <include name="my_print_defaults"/>
+                <include name="resolveip"/>
+            </fileset>
+        </copy>
+
+        <echo message="Copying scripts files" />
+        <copy file="${project.build.directory}/mariadb-${mariaDB.version}-linux-systemd-x86_64/scripts/mariadb-install-db"
+              tofile="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux/scripts/mariadb-install-db">
+        </copy>
+
+        <chmod dir="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/linux/bin" perm="ugo+rx"
+                includes="*"/>                               
+    </target>
+</project>

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/pom.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ch.vorburger.mariaDB4j</groupId>
+        <artifactId>mariaDB4j-pom-lite</artifactId>
+        <version>2.2.1</version>
+        <relativePath>../../mariaDB4j-pom-lite/pom.xml</relativePath>
+    </parent>
+
+	<artifactId>mariaDB4j-db-winx64</artifactId>
+    <version>10.6.12</version>
+
+    <properties>
+        <mariaDB.version>${project.version}</mariaDB.version>
+        <cacheDir>${project.basedir}/../../../tmpDir</cacheDir>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.build.directory}/generated-resources</directory>
+            </resource>
+        </resources>
+        <plugins>         
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>generate-resources</id>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <target>
+                                <property name="project.basedir" value="${project.basedir}"/>
+                                <property name="project.build.directory" value="${project.build.directory}"/>
+                                <property name="cacheDir" value="${cacheDir}"/>
+                                <property name="mariaDB.version" value="${mariaDB.version}"/>
+                                <ant antfile="${project.basedir}/prepare.xml">
+                                </ant>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>        
+        </plugins>
+    </build>
+</project>

--- a/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/prepare.xml
+++ b/DBs/mariaDB4j-db-10.6.12/mariaDB4j-db-winx64-10.6.12/prepare.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<project name="MariaDB4J" default="extract" >
+    <description>
+        Ant task to download file from internet and extract during maven package
+    </description>
+
+    <target name="env">
+        <echo message="Project path   : ${project.basedir}"/>
+        <echo message="Output location: ${project.build.directory}"/>
+        <echo message="Cache location : ${cacheDir}"/>
+        <echo message="MariaDB version: ${mariaDB.version}"/>
+        <mkdir dir="${cacheDir}" />
+        <mkdir dir="${cacheDir}/input" />
+    </target>
+
+    <target name="download" depends="env"
+        description="Download Windows zip file from mariadb.com">
+        <echo message="Downloading Windows MariaDB ${mariaDB.version} file ..." />
+        <get src="https://dlm.mariadb.com/2830119/MariaDB/mariadb-${mariaDB.version}/winx64-packages/mariadb-${mariaDB.version}-winx64.zip"
+            skipexisting="true" 
+            dest="${cacheDir}/input/mariadb-${mariaDB.version}-winx64.zip" />
+    </target>
+
+    <!--- As of MariaDB 10.5.2, the original mysql* bins are sym links to mariadb equivalents.
+    Sym links do not work in jar files as they are not platform independent
+    We copy over the mariadb* names and the code has been updated to use these new binaries
+    https://jira.mariadb.org/browse/MDEV-21303
+    -->
+    <target name="extract" depends="env,download"
+        description="Extract project files">
+        <echo message="Extracting zip file" />
+        <unzip src="${cacheDir}/input/mariadb-${mariaDB.version}-winx64.zip" 
+                dest="${project.build.directory}/generated-resources/ch/vorburger/mariadb4j/mariadb-${mariaDB.version}/winx64"
+                overwrite="true">
+            <patternset>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadb.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadbd.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadb-check.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadb-dump.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/mariadb-install-db.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/bin/my_print_defaults.exe"/>
+                <include name="mariadb-${mariaDB.version}-winx64/share/**/*"/>
+            </patternset>
+            <mapper>
+                <globmapper from="mariadb-${mariaDB.version}-winx64/*" to="*"/>
+            </mapper>
+        </unzip>
+    </target>
+</project>

--- a/DBs/mariaDB4j-db-10.6.12/pom.xml
+++ b/DBs/mariaDB4j-db-10.6.12/pom.xml
@@ -13,30 +13,15 @@
         <relativePath>../mariaDB4j-pom-lite/pom.xml</relativePath>
     </parent>
 
-    <artifactId>mariaDB4j-binaries</artifactId>
-    <name>mariaDB4j Platform binaries</name>
+    <artifactId>mariaDB4j-10.6.12-binaries</artifactId>
+    <name>mariaDB4j 10.6.12 binaries</name>
     <!-- This artefact is never released, and just used in ../.travis.yml, so let's use a special marker version to make that clear -->
     <version>0.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
-<!--        <module>mariaDB4j-db-win32-10.6.12</module>-->
-        <module>mariaDB4j-db-win32-10.2.11</module>
-        <module>mariaDB4j-db-win32-10.1.23</module>
-        <module>mariaDB4j-db-win32-10.1.20</module>
-        <module>mariaDB4j-db-win32-10.0.13</module>
-
-<!--        <module>mariaDB4j-db-mac64-10.6.12</module>-->
-	    <module>mariaDB4j-db-mac64-10.2.11</module>
-        <module>mariaDB4j-db-mac64-10.1.23</module>
-        <module>mariaDB4j-db-mac64-10.1.9</module>
-        <module>mariaDB4j-db-mac64-5.5.34</module>
-
-<!--        <module>mariaDB4j-db-linux64-10.6.12</module>-->
-        <module>mariaDB4j-db-linux64-10.2.11</module>
-        <module>mariaDB4j-db-linux64-10.1.23</module>
-        <module>mariaDB4j-db-linux64-10.1.13</module>
-
-	<module>mariaDB4j-db-10.3</module>
+        <module>mariaDB4j-db-linux64-10.6.12</module>
+        <!-- no support for osx, see PR commentary -->
+        <module>mariaDB4j-db-win64-10.6.12</module>
     </modules>
 </project>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ MariaDB4j JAR binaries are available from:
 <dependency>
     <groupId>ch.vorburger.mariaDB4j</groupId>
     <artifactId>mariaDB4j</artifactId>
-    <version>3.0.0</version>
+    <version>2.7.0</version>
 </dependency>
 ```
 
@@ -146,7 +146,7 @@ source; just git clone this and then mvn install or deploy. -- MariaDB4j's Maven
 <dependency>
     <groupId>ch.vorburger.mariaDB4j</groupId>
     <artifactId>mariaDB4j</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.7.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/mariaDB4j-app/pom.xml
+++ b/mariaDB4j-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ch.vorburger.mariaDB4j</groupId>
 		<artifactId>mariaDB4j-pom</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>2.7.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ch.vorburger.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -109,7 +109,7 @@ public class DB {
         logger.info("Installing a new embedded database to: " + baseDir);
         File installDbCmdFile = configuration.getExecutable(Executable.InstallDB);
         ManagedProcessBuilder builder = new ManagedProcessBuilder(installDbCmdFile);
-        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mysql_install_db"));
+        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mariadb-install-db"));
         builder.getEnvironment().put(configuration.getOSLibraryEnvironmentVarName(), libDir.getAbsolutePath());
         builder.setWorkingDirectory(baseDir);
         if (!configuration.isWindows()) {
@@ -155,7 +155,7 @@ public class DB {
             mysqldProcess = startPreparation();
             ready = mysqldProcess.startAndWaitForConsoleMessageMaxMs(getReadyForConnectionsTag(), dbStartMaxWaitInMS);
         } catch (Exception e) {
-            logger.error("failed to start mysqld", e);
+            logger.error("failed to start mariadbd", e);
             throw new ManagedProcessException("An error occurred while starting the database", e);
         }
         if (!ready) {
@@ -174,7 +174,7 @@ public class DB {
 
     synchronized ManagedProcess startPreparation() throws ManagedProcessException, IOException {
         ManagedProcessBuilder builder = new ManagedProcessBuilder(configuration.getExecutable(Server));
-        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mysqld"));
+        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mariadbd"));
         builder.getEnvironment().put(configuration.getOSLibraryEnvironmentVarName(), libDir.getAbsolutePath());
         builder.addArgument("--no-defaults"); // *** THIS MUST COME FIRST ***
         builder.addArgument("--console");
@@ -203,7 +203,7 @@ public class DB {
         // because cleanupOnExit() just installed our (class DB) own
         // Shutdown hook, we don't need the one from ManagedProcess:
         builder.setDestroyOnShutdown(false);
-        logger.info("mysqld executable: " + builder.getExecutable());
+        logger.info("mariadbd executable: " + builder.getExecutable());
         return builder.build();
     }
 
@@ -342,7 +342,7 @@ public class DB {
         logger.info("Running a " + logInfoText);
         try {
             ManagedProcessBuilder builder = new ManagedProcessBuilder(configuration.getExecutable(Client));
-            builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mysql"));
+            builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mariadb"));
             builder.setWorkingDirectory(baseDir);
             builder.addArgument("--default-character-set=utf8");
             if (username != null && !username.isEmpty()) {
@@ -485,7 +485,7 @@ public class DB {
 
         BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(outputFile));
         builder.addStdOut(outputStream);
-        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mysqldump"));
+        builder.setOutputStreamLogDispatcher(getOutputStreamLogDispatcher("mariadb-dump"));
         builder.addArgument("--port=" + configuration.getPort());
         if (!configuration.isWindows()) {
             builder.addFileArgument("--socket", getAbsoluteSocketFile());

--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DBConfigurationBuilder.java
@@ -43,7 +43,7 @@ import org.apache.commons.lang3.SystemUtils;
  */
 public class DBConfigurationBuilder {
 
-    protected static final String WIN32 = "win32";
+    protected static final String WINX64 = "winx64";
     protected static final String LINUX = "linux";
     protected static final String OSX = "osx";
 
@@ -54,7 +54,7 @@ public class DBConfigurationBuilder {
     private String databaseVersion = null;
 
     // all these are just some defaults
-    protected String osDirectoryName = SystemUtils.IS_OS_WINDOWS ? WIN32 : SystemUtils.IS_OS_MAC ? OSX : LINUX;
+    protected String osDirectoryName = SystemUtils.IS_OS_WINDOWS ? WINX64 : SystemUtils.IS_OS_MAC ? OSX : LINUX;
     protected String baseDir = SystemUtils.JAVA_IO_TMPDIR + "/MariaDB4j/base";
     protected String libDir = null;
 
@@ -289,11 +289,11 @@ public class DBConfigurationBuilder {
     protected String _getDatabaseVersion() {
         String databaseVersion = getDatabaseVersion();
         if (databaseVersion == null) {
-            if (!OSX.equals(getOS()) && !LINUX.equals(getOS()) && !WIN32.equals(getOS())) {
+            if (!OSX.equals(getOS()) && !LINUX.equals(getOS()) && !WINX64.equals(getOS())) {
                 throw new IllegalStateException("OS not directly supported, please use setDatabaseVersion() to set the name "
                         + "of the package that the binaries are in, for: " + SystemUtils.OS_VERSION);
             }
-            databaseVersion = "mariadb-10.2.11";
+            databaseVersion = "mariadb-10.6.12";
         }
         return databaseVersion;
     }
@@ -368,23 +368,23 @@ public class DBConfigurationBuilder {
     }
 
     protected Map<Executable, Supplier<File>> _getExecutables() {
-        executables.putIfAbsent(Server, () -> new File(baseDir, "bin/mysqld" + getExtension()));
-        executables.putIfAbsent(Client, () -> new File(baseDir, "bin/mysql" + getExtension()));
-        executables.putIfAbsent(Dump, () -> new File(baseDir, "bin/mysqldump" + getExtension()));
+        executables.putIfAbsent(Server, () -> new File(baseDir, "bin/mariadbd" + getExtension()));
+        executables.putIfAbsent(Client, () -> new File(baseDir, "bin/mariadb" + getExtension()));
+        executables.putIfAbsent(Dump, () -> new File(baseDir, "bin/mariadb-dump" + getExtension()));
         executables.putIfAbsent(PrintDefaults, () -> new File(baseDir, "bin/my_print_defaults" + getExtension()));
         executables.putIfAbsent(InstallDB, () -> {
-            File bin = new File(baseDir, "bin/mysql_install_db" + getExtension());
+            File bin = new File(baseDir, "bin/mariadb-install-db" + getExtension());
             if (bin.exists()) {
                 return bin;
             }
-            return new File(baseDir, "scripts/mysql_install_db" + getExtension());
+            return new File(baseDir, "scripts/mariadb-install-db" + getExtension());
         });
 
         return executables;
     }
 
     public boolean isWindows() {
-        return WIN32.equals(getOS());
+        return WINX64.equals(getOS());
     }
 
     protected String getExtension() {

--- a/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
+++ b/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
@@ -183,7 +183,7 @@ public class DBConfigurationBuilderTest {
     @Test public void defaultExecutables() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         DBConfiguration config = builder.build();
-        assertTrue(config.getExecutable(Executable.Server).toString().contains("MariaDB4j/base/bin/mysqld"));
+        assertTrue(config.getExecutable(Executable.Server).toString().contains("MariaDB4j/base/bin/mariadbd"));
     }
 
     @Test public void customExecutables() {

--- a/mariaDB4j-maven-plugin/pom.xml
+++ b/mariaDB4j-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ch.vorburger.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j-springboot/pom.xml
+++ b/mariaDB4j-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ch.vorburger.mariaDB4j</groupId>
         <artifactId>mariaDB4j-pom</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mariaDB4j/pom.xml
+++ b/mariaDB4j/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ch.vorburger.mariaDB4j</groupId>
 		<artifactId>mariaDB4j-pom</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>2.7.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -23,18 +23,14 @@
 		<dependency>
 			<groupId>ch.vorburger.mariaDB4j</groupId>
 			<artifactId>mariaDB4j-db-linux64</artifactId>
-			<version>10.2.11</version>
+			<version>10.6.12</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.vorburger.mariaDB4j</groupId>
-			<artifactId>mariaDB4j-db-win32</artifactId>
-			<version>10.2.11</version>
+			<artifactId>mariaDB4j-db-winx64</artifactId>
+			<version>10.6.12</version>
 		</dependency>
-		<dependency>
-			<groupId>ch.vorburger.mariaDB4j</groupId>
-			<artifactId>mariaDB4j-db-mac64</artifactId>
-			<version>10.2.11</version>
-		</dependency>
+		<!-- no support for osx, see PR commentary -->
 		<dependency>
 			<!-- For MariaDB4jSpringService, only. This has to be repeated from mariaDB4j-core here
 			due to the optional true below -->

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
@@ -38,17 +38,21 @@ import org.junit.Test;
  */
 public class StartSimulatedForAllPlatformsTest {
 
-    @Test public void simulatedStartWin32() throws Exception {
-        checkPlatformStart(DBConfigurationBuilder.WIN32);
+    @Test public void simulatedStartWinx64() throws Exception {
+        checkPlatformStart(DBConfigurationBuilder.WINX64);
     }
 
     @Test public void simulatedStartLinux() throws Exception {
         checkPlatformStart(DBConfigurationBuilder.LINUX);
     }
 
-    @Test public void simulatedStartOSX() throws Exception {
-        checkPlatformStart(DBConfigurationBuilder.OSX);
-    }
+    // Commented out for 10.6.12 binary addition
+    // With the decommission of bintray in 2021 and the move of OCI images to GitHub Content Repo
+    // as docker images, it was impossible to unpack a version for DBs/.
+    // See additional commentary in the PR.
+//    @Test public void simulatedStartOSX() throws Exception {
+//        checkPlatformStart(DBConfigurationBuilder.OSX);
+//    }
 
     void checkPlatformStart(String platform) throws ManagedProcessException, IOException {
         DBConfigurationBuilder configBuilder = DBConfigurationBuilder.newBuilder();

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
 	<artifactId>mariaDB4j-pom</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>2.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
     <scm>
@@ -43,6 +43,7 @@
 		 <springboot.version>2.7.5</springboot.version>
 		 <maven.compiler.source>11</maven.compiler.source>
 		 <maven.compiler.target>11</maven.compiler.target>
+		 <slf4j.version>2.0.6</slf4j.version>
 	</properties>
 
 	<build>
@@ -155,10 +156,15 @@
 	            <type>pom</type>
 	            <scope>import</scope>
 	        </dependency>
+			 <dependency>
+				 <groupId>org.slf4j</groupId>
+				 <artifactId>slf4j-api</artifactId>
+				 <version>${slf4j.version}</version>
+			 </dependency>
 	        <dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-simple</artifactId>
-	            <version>2.0.6</version>
+				<version>${slf4j.version}</version>
 	            <scope>test</scope>
 			</dependency>
             <dependency>


### PR DESCRIPTION
Initial working pass of MariaDB 10.6.12 for linux with a simulated start for winx64. OSX support is currently not available.  

Opening this PR knowing it cannot currently be merged to main. I am looking for additional eyes on this and suggestions.

Originally, I branched off of the last commit prior to the upgrade to Java 17. 

After I attempted to use it in my software (Java 11, Spring 5 / Boot 2.7.x), I ran into an issue where the annotations had been switched from javax to jakarta as part of the move to Spring 6. I then moved my branch to right before this change.

I would like to suggest creating a 2.x release branch that maintains a Java 11 / Spring 5 release and allow 3.x + to be Java 17 onwards. But this becomes a nightmare quickly because more recent MariaDB instances are not necessarily tied to the user's Java version, nor what version of Spring they are using. Fixes to MariaDB4j itself would then need to get backpatched to prior release branches as applicable.

The compatibility matrix effectively becomes MariaDB / Spring Framework / this product.

I don't mind doing the work for this, but at what point do we want cutoff retrofitting here versus maintaining a hard fork? Open to suggestions.

Having that said, this update was quite bespoke. In no particular order, several challenges that had to be solved to get 10.6.12 working in Linux:

1. MariaDB changed their download urls since the 10.3 commit to this repository.
2. MariaDB 10.4 removed no password root user. Additional commentary below
3. MariaDB 10.5.2 onward swapped how they did sym links between mysql* and maria* equivalents. Additional commentary below
4. OSX support was incomprehensible.
5. Consolidated slf4j to version 2.0.6. 1.7.x and 2.x results in NOOP binding

**DL URL**

https://dlm.mariadb.com/browse/mariadb_server/ ... versus the previous url in 10.3

Looks like Win32 support was dropped at some point.

**Root user:**

https://mariadb.com/kb/en/authentication-from-mariadb-104/

You can use the user that owns the data directory (generally the user that started MariaDB4j) to give the root user a password to continue the functionality of the unit tests.

**Sym links:**

I updated the entire codebase to reference maria* instead of mysql for binaries.

**OSX:**

Bintray was decommisioned in May 2021. Homebrew OCI got moved to Github Content Repository which is a Docker repo. After a lot of hunting and trying to figure out how to at least simulate a download, I got stuck at pulling the OCI from GHCR here: 

https://github.com/Homebrew/homebrew-core/pkgs/container/core%2Fmariadb%2F10.6/69479903?tag=10.6.12

Because I was not on the right OS, docker would not pull. 

I believe people have ran into this before and effectively have to build from source themselves or be on osx.