### PR TITLE
Bump ch.vorburger.exec to 3.1.4 (fixes #233)

### DIFF
--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>ch.vorburger.exec</groupId>
             <artifactId>exec</artifactId>
-            <version>3.1.3</version>
+            <version>3.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
for https://github.com/vorburger/ch.vorburger.exec/pull/103 and https://github.com/vorburger/ch.vorburger.exec/pull/96 for (finally) https://github.com/vorburger/MariaDB4j/issues/233!